### PR TITLE
fix: 회원정보 불러오기 및 수정 로직의 API 연동 문제 해결

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,2 +1,2 @@
-VITE_API_BASE_URL=https://api.example.com
+VITE_API_BASE_URL=http://localhost:8080
 VITE_FRONTEND_BASE_URL=http://localhost:5173

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "formik": "^2.4.6",
+        "jwt-decode": "^4.0.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.5.3",
@@ -3232,6 +3233,15 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "formik": "^2.4.6",
+    "jwt-decode": "^4.0.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.5.3",

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -27,7 +27,7 @@ export const Header = ({ className: _className }: HeaderProps) => {
         onClick={() => useSidebarStore.getState().toggle()}
       />
       <Link to={ROUTES.MAIN}>
-        <Text className="text-2xl font-extrabold cursor-pointer">탐나라</Text>
+        <Text className="text-2xl font-extrabold cursor-pointer text-headerTextColor">탐나라</Text>
       </Link>
       <Icon name="MagnifyingGlassIcon" size={24} variant="solid" className="text-headerIconColor cursor-pointer" />
     </div>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -2,10 +2,10 @@ import { useEffect, useRef } from 'react';
 import { useSidebarStore } from '@/stores/sidebarStore';
 import clsx from 'clsx';
 import { Link } from 'react-router-dom';
-import { ENDPOINTS, INQUIRY_URL, ROUTES } from '@/constants/url';
+import { INQUIRY_URL, ROUTES } from '@/constants/url';
 import { Icon } from '../ui/Icon';
 import { Text } from '../ui/Text';
-import { ApiButton } from '../ui/Button';
+import { LogoutButton } from '../ui/Button';
 import { useAuthStore } from '@/stores/authStore';
 
 export const Sidebar = () => {
@@ -64,15 +64,10 @@ export const Sidebar = () => {
             <Link to={ROUTES.USER_INFO} className={navItemClass} onClick={close}>
               회원정보 수정
             </Link>
-            <ApiButton
-              method="POST"
-              url={ENDPOINTS.LOGOUT}
-              redirectTo={ROUTES.MAIN}
+            <LogoutButton
               className={clsx(navItemClass, 'block text-left')}
               onClick={close}
-            >
-              로그아웃
-            </ApiButton>
+            />
           </nav>
         </div>
       ) : (

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -72,6 +72,7 @@ export const LogoutButton = ({
         localStorage.removeItem('userName')
         localStorage.removeItem('role')
         navigate(ROUTES.MAIN);
+        window.location.reload()
       }
 
       if (onClick) {

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,59 +1,90 @@
 import { useNavigate } from 'react-router-dom';
 import { useRequestStore } from '@/stores/requestStore';
 import clsx from 'clsx';
+import type { DetailedHTMLProps, HTMLAttributes } from 'node_modules/@types/react';
+import { ENDPOINTS, ROUTES } from '@/constants/url';
 
-interface ApiButtonProps {
-  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
-  url: string;
-  data?: any;
-  redirectTo?: string;
-  className?: string;
-  children: React.ReactNode;
-  onClick?: () => void;
+type SideBarButtonProps = DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> & {
+  url: string
+  data?: any
+  redirectTo?: string
+  children: React.ReactNode
+  onClick?: () => void
 }
 
-export const ApiButton = ({
-  method,
-  url,
-  data,
-  redirectTo,
-  className,
-  children,
-  onClick,
-}: ApiButtonProps) => {
+export const SideBarButton = ({
+  url, data, redirectTo,
+  children, onClick,
+  className: _className
+}: SideBarButtonProps) => {
+  const className = clsx(_className)
+
   const navigate = useNavigate();
-  const {
-    getData,
-    postData,
-    putData,
-    patchData,
-    deleteData,
-  } = useRequestStore();
+  const { postData } = useRequestStore();
 
   const handleClick = async () => {
     try {
-      const res =
-        method === 'GET' ? await getData(url) :
-        method === 'POST' ? await postData(url, data) :
-        method === 'PUT' ? await putData(url, data) :
-        method === 'PATCH' ? await patchData(url, data) :
-        await deleteData(url);
-
-      if (res?.success && redirectTo) {
-        navigate(redirectTo);
+      if (data) {
+        const res = await postData(url, data)
+        if (res?.success && redirectTo) {
+          navigate(redirectTo);
+        }
+      } else {
+        const res = await postData(url)
+        if (res?.success && redirectTo) {
+          navigate(redirectTo);
+        }
       }
 
       if (onClick) {
         onClick();
       }
     } catch (error) {
-      console.error(`[${method}] 요청 실패:`, error);
+      console.error(`요청 처리 실패:`, error);
     }
   };
 
   return (
     <button className={clsx(className)} onClick={handleClick}>
       {children}
+    </button>
+  );
+};
+
+type LogoutButtonProps = DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> & {
+  onClick?: () => void
+}
+
+export const LogoutButton = ({
+  onClick, className: _className
+}: LogoutButtonProps) => {
+  const className = clsx(_className)
+
+  const navigate = useNavigate();
+  const { postData } = useRequestStore();
+
+  const handleClick = async () => {
+    try {
+      const res = await postData(ENDPOINTS.LOGOUT)
+      if (res?.success) {
+        localStorage.removeItem('token')
+        localStorage.removeItem('userId')
+        localStorage.removeItem('userName')
+        localStorage.removeItem('role')
+        navigate(ROUTES.MAIN);
+      }
+
+      if (onClick) {
+        onClick();
+      }
+    } catch (error) {
+      console.error(`로그아웃 실패:`, error);
+    }
+  };
+
+  return (
+    <button className={clsx(className)} onClick={handleClick}>
+      로그아웃
     </button>
   );
 };

--- a/frontend/src/constants/url.ts
+++ b/frontend/src/constants/url.ts
@@ -12,6 +12,7 @@ if (!API_BASE_URL) {
 export const ROUTES = {
   MAIN: '/main',
   LOGIN: '/login',
+  KAKAO_CALLBACK: "/auth/kakao/callback",
   SIGNUP: '/signup',
   USER_INFO: '/user-info',
   NEWS_DETAIL: '/news/:id',
@@ -20,7 +21,8 @@ export const ROUTES = {
 
 export const ENDPOINTS = {
   LOGIN: '/auth/login',
-  KAKAO_LOGIN: '/auth/login/kakao',
+  KAKAO_LOGIN: '/auth/kakao/login-url',
+  KAKAO_LOGIN_CALLBACK: (code: string) => `/auth/kakao/callback?code=${code}`,
   LOGOUT: '/users/logout',
   SIGNUP: '/users',
   CHECK_EMAIL: (email: string) => `/users/check-email?email=${encodeURIComponent(email)}`,

--- a/frontend/src/lib/axios.ts
+++ b/frontend/src/lib/axios.ts
@@ -7,5 +7,14 @@ export const axiosInstance = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
-  timeout: 10000, // 10초
+  timeout: 10000,
+})
+
+axiosInstance.interceptors.request.use((config) => {
+  const token = localStorage.getItem('token')
+  if (token) {
+    config.headers = config.headers || {}
+    config.headers['Authorization'] = `Bearer ${token}`
+  }
+  return config
 })

--- a/frontend/src/pages/PU/PU-003/UserInfoLogic.ts
+++ b/frontend/src/pages/PU/PU-003/UserInfoLogic.ts
@@ -2,6 +2,8 @@ import { useEffect, useState, type DetailedHTMLProps, type HTMLAttributes } from
 import { useRequestStore } from "@/stores/requestStore";
 import { ENDPOINTS } from "@/constants/url";
 import { validateUserInfo } from "../utils/validateUserInfo";
+import { useNavigate } from 'react-router-dom';
+import { ROUTES } from "@/constants/url";
 
 type UserInfoLogicProps = DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> & {
   setToastMessage: (msg: string) => void;
@@ -17,14 +19,22 @@ export const useUserInfoLogic = ({ setToastMessage }: UserInfoLogicProps ) => {
   const [isNameChecked, setIsNameChecked] = useState(false)
 
   const { getData, postData } = useRequestStore();
+  const navigate  = useNavigate();
+  const userName = localStorage.getItem('userName');
 
   useEffect(() => {
-    setName(localStorage.getItem('userName') ?? '');
+    if (!userName) {
+      alert('로그인 정보가 없습니다. 다시 로그인해주세요.');
+      navigate(ROUTES.LOGIN);
+      return;
+    }
+
+    setName(userName);
     
     const fetchUserInfo = async () => {
       try {
         const res = await getData(ENDPOINTS.USER_INFO);
-        setEmail(res.data.email);
+        setEmail(res.data.user.email);
       } catch (e) {
         console.error("유저 정보 조회 실패", e);
       }
@@ -32,10 +42,8 @@ export const useUserInfoLogic = ({ setToastMessage }: UserInfoLogicProps ) => {
     fetchUserInfo();
   }, []);
 
-  useEffect(() => {
-    const prevName = localStorage.getItem("userName");
-  
-    if (name === prevName) {
+  useEffect(() => { 
+    if (name === userName) {
       setErrors({});
       setIsButtonActive(false);
       return;

--- a/frontend/src/pages/PU/PU-003/UserInfoLogic.ts
+++ b/frontend/src/pages/PU/PU-003/UserInfoLogic.ts
@@ -10,7 +10,7 @@ type UserInfoLogicProps = DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTML
 export const useUserInfoLogic = ({ setToastMessage }: UserInfoLogicProps ) => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState('')
-  const [name, setName] = useState("");
+  const [name, setName] = useState('');
   const [errors, setErrors] = useState<{ name?: string }>({});
   const [isButtonActive, setIsButtonActive] = useState(false);
   const [isInputModalOpen, setIsInputModalOpen] = useState(false)
@@ -19,11 +19,12 @@ export const useUserInfoLogic = ({ setToastMessage }: UserInfoLogicProps ) => {
   const { getData, postData } = useRequestStore();
 
   useEffect(() => {
+    setName(localStorage.getItem('userName') ?? '');
+    
     const fetchUserInfo = async () => {
       try {
         const res = await getData(ENDPOINTS.USER_INFO);
         setEmail(res.data.email);
-        setName(res.data.username);
       } catch (e) {
         console.error("유저 정보 조회 실패", e);
       }
@@ -32,7 +33,7 @@ export const useUserInfoLogic = ({ setToastMessage }: UserInfoLogicProps ) => {
   }, []);
 
   useEffect(() => {
-    const prevName = localStorage.getItem("name");
+    const prevName = localStorage.getItem("userName");
   
     if (name === prevName) {
       setErrors({});

--- a/frontend/src/pages/PU/PU-003/index.tsx
+++ b/frontend/src/pages/PU/PU-003/index.tsx
@@ -1,10 +1,7 @@
 import { Wrapper } from "../components/layout/Wrapper";
-import { KaKaoButton } from "../components/ui/Button";
 import { UserInfoForm } from "./UserInfoForm";
 
 export default function UserInfoPage() {
-  const lineClass = 'border-t border-lineColor my-5';
-
   return (
     <div className="wrap bg-puBgColor">
       <Wrapper
@@ -12,10 +9,6 @@ export default function UserInfoPage() {
         className="px-8"
       >
         <UserInfoForm /> 
-        <div className={lineClass} />
-        <KaKaoButton
-          accessToken={localStorage.getItem('accessToken') ?? ''}
-        />
       </Wrapper>
     </div>
   )

--- a/frontend/src/pages/PU/auth/KakaoCallback.tsx
+++ b/frontend/src/pages/PU/auth/KakaoCallback.tsx
@@ -1,0 +1,42 @@
+import { useEffect } from "react";
+import { useSearchParams, useNavigate } from "react-router-dom";
+import { ENDPOINTS, ROUTES } from "@/constants/url";
+import { handleToken } from "@/utils/handleToken";
+import { axiosInstance } from "@/lib/axios";
+
+export const KakaoCallback = () => {
+  const [searchParams] = useSearchParams();
+  const code = searchParams.get("code");
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const fetchToken = async () => {
+      if (!code) return;
+      try {
+        const res = await axiosInstance.get(ENDPOINTS.KAKAO_LOGIN_CALLBACK(code), {
+          validateStatus: () => true,
+        });
+
+        const authHeader = res.headers["authorization"];
+
+        if (!authHeader || !authHeader.startsWith("Bearer ")) {
+          throw new Error("Authorization 헤더가 없습니다.");
+        }
+
+        const token = authHeader.replace("Bearer ", "");
+
+        handleToken(token);
+        navigate(ROUTES.MAIN);
+        window.location.reload();
+      } catch (err) {
+        console.error("카카오 콜백 처리 실패", err);
+        alert("로그인에 실패했습니다.");
+        navigate(ROUTES.LOGIN);
+      }
+    };
+
+    fetchToken();
+  }, [code]);
+
+  return <div>카카오 로그인 처리 중입니다...</div>;
+};

--- a/frontend/src/pages/PU/components/ui/Button.tsx
+++ b/frontend/src/pages/PU/components/ui/Button.tsx
@@ -20,7 +20,7 @@ export const Button = ({
 
   const className = clsx(
     buttonClass,
-    isActive ? 'bg-buttonActiveColor' : 'bg-buttonDisactiveColor',
+    isActive ? 'bg-buttonActiveColor' : 'bg-buttonInactiveColor',
     _className
   )
 

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -24,27 +24,27 @@ function isTokenValid(token: string | null): boolean {
 }
 
 export const useAuthStore = create<AuthState>((set) => {
-  const token = localStorage.getItem('accessToken');
+  const token = localStorage.getItem('token');
   const initialLoginState = isTokenValid(token);
 
   return {
     isLoggedIn: initialLoginState,
 
     login: (token: string) => {
-      localStorage.setItem('accessToken', token);
+      localStorage.setItem('token', token);
       set({ isLoggedIn: true });
     },
 
     logout: () => {
-      localStorage.removeItem('accessToken');
+      localStorage.removeItem('token');
       set({ isLoggedIn: false });
     },
 
     checkAuth: () => {
-      const token = localStorage.getItem('accessToken');
+      const token = localStorage.getItem('token');
       const isValid = isTokenValid(token);
       set({ isLoggedIn: isValid });
-      if (!isValid) localStorage.removeItem('accessToken');
+      if (!isValid) localStorage.removeItem('token');
     },
   };
 });

--- a/frontend/src/stores/requestStore.ts
+++ b/frontend/src/stores/requestStore.ts
@@ -1,66 +1,66 @@
-import { create } from 'zustand'
+import { create } from 'zustand';
 import type { AxiosRequestConfig } from 'axios';
-import { axiosInstance } from '@/lib/axios'
+import { axiosInstance } from '@/lib/axios';
 
 interface RequestState {
-  isLoading: boolean
-  getData: <T = any>(url: string, config?: AxiosRequestConfig) => Promise<T>
-  postData: <T = any>(url: string, data: any, config?: AxiosRequestConfig) => Promise<T>
-  patchData: <T = any>(url: string, data: any, config?: AxiosRequestConfig) => Promise<T>
-  putData: <T = any>(url: string, data: any, config?: AxiosRequestConfig) => Promise<T>
-  deleteData: <T = any>(url: string, config?: AxiosRequestConfig) => Promise<T>
+  isLoading: boolean;
+  getData: <T = any>(url: string, config?: AxiosRequestConfig) => Promise<T>;
+  postData: <T = any>(url: string, data?: any, config?: AxiosRequestConfig) => Promise<T>;
+  patchData: <T = any>(url: string, data?: any, config?: AxiosRequestConfig) => Promise<T>;
+  putData: <T = any>(url: string, data?: any, config?: AxiosRequestConfig) => Promise<T>;
+  deleteData: <T = any>(url: string, config?: AxiosRequestConfig) => Promise<T>;
 }
 
 export const useRequestStore = create<RequestState>((set) => ({
   isLoading: false,
 
   getData: async (url, config) => {
-    set({ isLoading: true })
+    set({ isLoading: true });
     try {
-      const res = await axiosInstance.get(url, config)
-      return res.data
+      const res = await axiosInstance.get(url, config);
+      return res.data;
     } finally {
-      set({ isLoading: false })
+      set({ isLoading: false });
     }
   },
 
   postData: async (url, data, config) => {
-    set({ isLoading: true })
+    set({ isLoading: true });
     try {
-      const res = await axiosInstance.post(url, data, config)
-      return res.data
+      const res = await axiosInstance.post(url, data, config);
+      return res.data;
     } finally {
-      set({ isLoading: false })
+      set({ isLoading: false });
     }
   },
 
   patchData: async (url, data, config) => {
-    set({ isLoading: true })
+    set({ isLoading: true });
     try {
-      const res = await axiosInstance.patch(url, data, config)
-      return res.data
+      const res = await axiosInstance.patch(url, data, config);
+      return res.data;
     } finally {
-      set({ isLoading: false })
+      set({ isLoading: false });
     }
   },
 
   putData: async (url, data, config) => {
-    set({ isLoading: true })
+    set({ isLoading: true });
     try {
-      const res = await axiosInstance.put(url, data, config)
-      return res.data
+      const res = await axiosInstance.put(url, data, config);
+      return res.data;
     } finally {
-      set({ isLoading: false })
+      set({ isLoading: false });
     }
   },
 
   deleteData: async (url, config) => {
-    set({ isLoading: true })
+    set({ isLoading: true });
     try {
-      const res = await axiosInstance.delete(url, config)
-      return res.data
+      const res = await axiosInstance.delete(url, config);
+      return res.data;
     } finally {
-      set({ isLoading: false })
+      set({ isLoading: false });
     }
   },
-}))
+}));

--- a/frontend/src/utils/handleToken.ts
+++ b/frontend/src/utils/handleToken.ts
@@ -17,6 +17,7 @@ export const handleToken = (token: string): void => {
     const decoded = jwtDecode<TokenJwtPayload>(token);
 
     if (isTokenExpired(decoded.exp)) {
+      console.log("액세스 토큰이 만로되었습니다.")
       localStorage.removeItem("token");
       localStorage.removeItem("userId");
       localStorage.removeItem("userName");

--- a/frontend/src/utils/handleToken.ts
+++ b/frontend/src/utils/handleToken.ts
@@ -1,0 +1,43 @@
+import { jwtDecode, type JwtPayload } from "jwt-decode";
+
+export interface TokenJwtPayload extends JwtPayload {
+  sub?: string;
+  username?: string;
+  role?: string;
+}
+
+const isTokenExpired = (exp?: number): boolean => {
+  if (!exp) return true;
+  const currentTime = Math.floor(Date.now() / 1000);
+  return exp < currentTime;
+};
+
+export const handleToken = (token: string): void => {
+  try {
+    const decoded = jwtDecode<TokenJwtPayload>(token);
+
+    if (isTokenExpired(decoded.exp)) {
+      localStorage.removeItem("token");
+      localStorage.removeItem("userId");
+      localStorage.removeItem("userName");
+      localStorage.removeItem("role");
+      return;
+    }
+
+    if (decoded.sub && decoded.username && decoded.role) {
+      localStorage.setItem("token", token);
+      localStorage.setItem("userId", decoded.sub);
+      localStorage.setItem("userName", decoded.username);
+      localStorage.setItem("role", decoded.role);
+    } else {
+      console.warn("JWT에서 필수 정보 누락: sub, username, role", {
+        sub: decoded.sub,
+        username: decoded.username,
+        role: decoded.role
+      }); 
+    }
+  } catch (error) {
+    console.error("JWT 처리 중 오류 발생:", error);
+    localStorage.clear();
+  }
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -17,6 +17,7 @@ export default {
 
         // CC-001
         headerColor: '#F2F2F2',
+        headerTextColor: '#000000',
         headerIconColor: '#000000',
 
         // CC-002


### PR DESCRIPTION
## 연관된 이슈
#6 #18 

<br/>

## 작업 내용
- [x] 화면에서 카카오 소설 로그인 버튼 제거
- [x] axios 요청 시 Authorization 헤더에 토큰 자동 추가 인터셉터 설정
- [x] API 명세서에 맞춰 응답 구조 및 요청 메서드 수정
- [x] 로그인되지 않은 사용자의 접근 방지 예외 처리 추가

<br/>

## 상세 내용
### axios 요청 시 Authorization 헤더에 토큰 자동 추가 인터셉터 설정
`/lib/axios.ts`
- 로컬스토리지에 저장해둔 액세스 토큰을 요청의 인증 헤더에 담아서 전달
```ts
axiosInstance.interceptors.request.use((config) => {
  const token = localStorage.getItem('token')
  if (token) {
    config.headers = config.headers || {}
    config.headers['Authorization'] = `Bearer ${token}`
  }
  return config
})
```