### PR TITLE
refactor: NewsCard 이미지 필드 네이밍 imageUrl → image 변경 및 뉴스 카드 레이아웃 고정

### DIFF
--- a/frontend/src/pages/PN/PN-001/Banner.tsx
+++ b/frontend/src/pages/PN/PN-001/Banner.tsx
@@ -16,7 +16,7 @@ interface NewsCard {
   id: number;
   title: string;
   summary: string;
-  imageUrl: string;
+  image: string;
   category: string;
   updatedAt: string;
   bookmarked: boolean;
@@ -37,7 +37,7 @@ const fallbackNewsCards: NewsCard[] = [
     id: 1, 
     title: '핫이슈 입니다 1', 
     summary: '핫이슈에 대한 간략한 설명입니다', 
-    imageUrl: 'https://picsum.photos/seed/1/400/200', 
+    image: 'https://picsum.photos/seed/1/400/200', 
     category: 'economy',
     updatedAt: '2025-04-17T12:00:00',
     bookmarked: false,
@@ -47,7 +47,7 @@ const fallbackNewsCards: NewsCard[] = [
     id: 2, 
     title: '핫이슈 입니다 2', 
     summary: '두 번째 핫이슈에 대한 간략한 설명입니다', 
-    imageUrl: 'https://picsum.photos/seed/2/400/200', 
+    image: 'https://picsum.photos/seed/2/400/200', 
     category: 'sports',
     updatedAt: '2025-04-16T15:30:00',
     bookmarked: true,
@@ -57,7 +57,7 @@ const fallbackNewsCards: NewsCard[] = [
     id: 3, 
     title: '핫이슈 일지도 아닐지도 모릅니다', 
     summary: '세 번째 핫이슈에 대한 간략한 설명입니다', 
-    imageUrl: 'https://picsum.photos/seed/3/400/200', 
+    image: 'https://picsum.photos/seed/3/400/200', 
     category: 'entertainment',
     updatedAt: '2025-04-15T09:45:00',
     bookmarked: false,
@@ -143,7 +143,7 @@ export const Banner: React.FC = () => {
         <SwiperSlide key={news.id}>
           <Link to={`/news/${news.id}`} className="relative block w-full h-full">
             <img
-              src={news.imageUrl}
+              src={news.image}
               alt={news.title}
               className="w-full h-full object-cover rounded-lg"
             />

--- a/frontend/src/pages/PN/PN-001/NewsList.tsx
+++ b/frontend/src/pages/PN/PN-001/NewsList.tsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect, useCallback, useRef } from 'react';
 interface News {
   id: string;
   title: string;
-  imageUrl: string;
+  image: string;
   category: string;
   createdAt: string;
   content: string;
@@ -29,7 +29,7 @@ export default function NewsList({ category }: NewsListProps) {
     const baseNews: News[] = Array.from({ length: pageSize }, (_, i) => ({
       id: `${page * pageSize + i + 1}`,
       title: `Sample News ${page * pageSize + i + 1}`,
-      imageUrl: `https://picsum.photos/seed/${page * pageSize + i + 1}/400/200`,
+      image: `https://picsum.photos/seed/${page * pageSize + i + 1}/400/200`,
       category: ['economy', 'sports', 'entertainment'][i % 3],
       createdAt: new Date(Date.now() - ((page - 1) * pageSize + i) * 24 * 60 * 60 * 1000).toISOString(),
       content: `뉴스 ${page * pageSize + i + 1}의 내용입니다. 내용이 길면 잘릴 수도 있습니다. 바로 이렇게요.`
@@ -40,7 +40,7 @@ export default function NewsList({ category }: NewsListProps) {
         {
           id: 'ktb-vote',
           title: '투표 페이지로 이동',
-          imageUrl: '',
+          image: '',
           category: 'ktb',
           createdAt: '',
           content: ''
@@ -122,11 +122,11 @@ export default function NewsList({ category }: NewsListProps) {
     return (
       <a
         href={`/news/${newsItem.id}`}
-        className="group flex flex-col md:flex-row items-center w-full overflow-hidden bg-white rounded-lg mb-4"
+        className="group flex flex-row items-center w-full overflow-hidden bg-white rounded-lg mb-4"
       >
         <div className="flex-shrink-0 w-[120px] h-[100px] flex items-center justify-center pl-3">
           <img
-            src={newsItem.imageUrl}
+            src={newsItem.image}
             alt={newsItem.title}
             className="w-[120px] h-[100px] object-cover transition-transform duration-300 group-hover:scale-105 rounded-lg"
           />


### PR DESCRIPTION
### 변경 내용
- NewsCard 및 News 타입의 이미지 필드를 기존 `imageUrl` → `image`로 통일하여 백엔드와 프론트의 필드 네이밍 일치
- 모든 더미 데이터와 API 응답 처리에서 `imageUrl` 대신 `image` 사용
- `NewsList` 및 `Banner` 컴포넌트 내 이미지 렌더링 시 `src={newsItem.image}`로 수정
- NewsItem 레이아웃에서 기존 반응형 클래스 `flex-col md:flex-row` 제거 → 항상 `flex-row` 고정
  - 모바일/데스크탑 구분 없이 동일 레이아웃 유지
  - 브라우저 너비 축소 시에도 레이아웃 변경 방지

### 이유
- 프론트-백엔드 간 응답 필드 네이밍 불일치로 발생하는 이미지 미출력 이슈 해결
- 레이아웃이 브라우저 너비에 따라 깨지는 현상 방지 (반응형 flex-col 제거)
- 모바일 고정 웹앱 스타일을 유지하기 위한 통일된 레이아웃 적용

### 테스트
- 로컬에서 뉴스 카드, 배너 정상 렌더링 확인
- 브라우저 너비를 줄여도 레이아웃 변경 없이 정상 유지 확인
