### PR TITLE
feat: 로그인 상태에 따른 라우팅 접근 제한 설정

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,8 @@ import { Container } from './components/layout/Container';
 import { Header } from './components/layout/Header';
 import { Sidebar } from './components/layout/Sidebar';
 import { KakaoCallback } from './pages/PU/auth/KakaoCallback';
+import { LogoutRoute } from './routes/LogoutRoute';
+import { LoginRoute } from './routes/LoginRoute';
 
 const App: React.FC = () => {
   const currentPage = usePageStore((state) => state.currentPage);
@@ -23,14 +25,35 @@ const App: React.FC = () => {
         <Sidebar />
         <Header />
         <Routes>
+          {/* 로그인 여부와 상관없이 접근 가능 */}
           <Route path="/" element={<Navigate to={currentPage} />} />
           <Route path={ROUTES.MAIN} element={<Main />} />
           <Route path={ROUTES.SEARCH_RESULTS} element={<SearchResults searchQuery={''} />} />
           <Route path={ROUTES.NEWS_DETAIL} element={<NewsDetail />} />
-          <Route path={ROUTES.KAKAO_CALLBACK} element={<KakaoCallback />} />
-          <Route path={ROUTES.SIGNUP} element={<SignUp />} />
-          <Route path={ROUTES.LOGIN} element={<Login />} />
-          <Route path={ROUTES.USER_INFO} element={<UserInfo />} />
+
+          {/* 로그아웃 상태에서만 접근 가능 */}
+          <Route path={ROUTES.SIGNUP} element={
+            <LogoutRoute>
+              <SignUp />
+            </LogoutRoute>
+          } />
+          <Route path={ROUTES.LOGIN} element={
+            <LogoutRoute>
+              <Login />
+            </LogoutRoute>
+          } />
+          <Route path={ROUTES.KAKAO_CALLBACK} element={
+            <LogoutRoute>
+              <KakaoCallback />
+            </LogoutRoute>
+          } />
+          
+          {/* 로그인 상태에서만 접근 가능 */}
+          <Route path={ROUTES.USER_INFO} element={
+            <LoginRoute>
+              <UserInfo />
+            </LoginRoute>
+          } />
         </Routes>
       </Router>
     </Container>

--- a/frontend/src/routes/LoginRoute.tsx
+++ b/frontend/src/routes/LoginRoute.tsx
@@ -1,0 +1,9 @@
+import type { PropsWithChildren } from 'react';
+import { Navigate } from "react-router-dom";
+import { useAuthStore } from "@/stores/authStore";
+import { ROUTES } from '@/constants/url';
+
+export const LoginRoute = ({ children }: PropsWithChildren) => {
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
+  return isLoggedIn ? children : <Navigate to={ROUTES.LOGIN} replace />;
+};

--- a/frontend/src/routes/LogoutRoute.tsx
+++ b/frontend/src/routes/LogoutRoute.tsx
@@ -1,0 +1,8 @@
+import type { PropsWithChildren } from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuthStore } from '@/stores/authStore';
+
+export const LogoutRoute = ({ children }: PropsWithChildren) => {
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
+  return isLoggedIn ? <Navigate to="/" replace /> : children;
+};


### PR DESCRIPTION
## 연관된 이슈
#34 

<br/>

## 작업 내용
- [x] 로그인 상태에 따른 라우팅 보호용 컴포넌트 추가
- [x] 라우터 설정에서 라우팅 보호용 컴포넌트로 감싸기

<br/>

## 상세 내용

### 로그인 상태에 따른 라우팅 보호용 컴포넌트 추가
- `/src/routes/LogoutRoute.tsx`: 로그아웃 상태에서만 접근 허용
- `/src/routes/LoginRoute.tsx`: 로그인 상태에서만 접근 허용

<br/>

### 라우터 설정에서 컴포넌트로 감싸기
 - 로그아웃 상태에서만 접근 가능: 회원가입, 로그인, 카카오 콜백 처리
 - 로그인 상태에서만 접근 가능: 회원정보 수정