### PR TITLE
fix: 닉네임 유효성 검사 추가 및 이메일 텍스트 색상에 누락된 Tailwind 클래스 추가

### DIFF
--- a/frontend/src/pages/PU/components/ui/StaticField.tsx
+++ b/frontend/src/pages/PU/components/ui/StaticField.tsx
@@ -14,7 +14,7 @@ export const StaticField = ({
   
   const containerClass = clsx('w-full flex flex-col justify-center', _className);
   const labelClass = clsx('text-base font-semibold text-labelTextColor')
-  const contentClass = clsx('text-base font-light text-staticTextColor')
+  const contentClass = clsx('text-base font-light text-myBlack')
   
   return (
     <Text className={containerClass}>

--- a/frontend/src/pages/PU/utils/validateUserInfo.ts
+++ b/frontend/src/pages/PU/utils/validateUserInfo.ts
@@ -9,11 +9,14 @@ export function validateUserInfo(
   name: string
 ): ValidationResult {
   const errors: ValidationResult["errors"] = {}
+  const nameRegex = /^[가-힣a-zA-Z0-9]+$/;
   
   if (!name.trim()) {
-    errors.name = "닉네임을 입력하세요."
+    errors.name = "닉네임을 입력하세요.";
   } else if (name.length > 10 || name.length < 2) {
-    errors.name = "2자 이상 10자 이내로 입력해 주세요."
+    errors.name = "2자 이상 10자 이내로 입력해 주세요.";
+  } else if (!nameRegex.test(name)) {
+    errors.name = "띄어쓰기 및 특수문자를 사용할 수 없습니다.";
   }
 
   return {

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -68,9 +68,6 @@ export default {
         navigationTextColor: '#000000',
         navigationTextHoverColor: '#A0A0A0',
 
-        navigationTextColor: '#000000',
-        navigationTextHoverColor: '#A0A0A0',
-
         // PN
         pnBgColor: '#FFFFFF',
         newsCardColor: '#DADADA',


### PR DESCRIPTION
## 연관된 이슈
#33 

<br/>

## 작업 내용
- [x] 닉네임에 띄어쓰기 및 특수문자 사용 제한 로직 추가
- [x] Tailwind 클래스에 StaticField의 content에 적용한 텍스트 색상 클래스 변경