### PR TITLE
chore: 메인페이지 UI 개선

### DIFF
--- a/frontend/src/pages/PN/PN-001/NewsList.tsx
+++ b/frontend/src/pages/PN/PN-001/NewsList.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import axios from 'axios';
 import { API_BASE_URL, ENDPOINTS } from '@/constants/url';
+import { formatRelativeTime } from '../utils/dateUtils';
 
 interface News {
   id: string;
@@ -74,8 +75,6 @@ export default function NewsList({ category }: NewsListProps) {
     fetchNews();
   }, [category]);
 
-  const formatDate = (dateString: string) => new Date(dateString).toLocaleDateString();
-
   const NewsItem = ({ newsItem }: { newsItem: News }) => (
     <a href={`/news/${newsItem.id}`} className="group flex flex-row items-center w-full overflow-hidden bg-white rounded-lg mb-4">
       <div className="flex-shrink-0 w-[120px] h-[100px] flex items-center justify-center pl-3 mt-2 mb-2">
@@ -103,7 +102,9 @@ export default function NewsList({ category }: NewsListProps) {
         <p className="text-gray-600 text-[14px] leading-snug mb-2 w-full text-right line-clamp-2">
           {newsItem.summary}
         </p>
-        <div className="text-[10px] text-[#F2A359]">{formatDate(newsItem.updatedAt)}</div>
+        <div className="w-full text-[10px] text-[#F2A359] text-right">
+          {formatRelativeTime(newsItem.updatedAt)} 업데이트
+        </div>
       </div>
     </a>
   );

--- a/frontend/src/pages/PN/PN-001/NewsList.tsx
+++ b/frontend/src/pages/PN/PN-001/NewsList.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import axios from 'axios';
 import { API_BASE_URL, ENDPOINTS } from '@/constants/url';
 
@@ -89,7 +89,9 @@ export default function NewsList({ category }: NewsListProps) {
       </div>
       <div className="p-4 flex-grow flex flex-col items-end text-right">
         <div className="flex justify-between items-start w-full">
-          <h3 className="text-lg font-semibold text-[20px] mb-1">{newsItem.title}</h3>
+        <h3 className="w-full text-lg font-semibold text-[20px] leading-tight mb-2 line-clamp-2 text-right">
+          {newsItem.title}
+        </h3>
           {newsItem.bookmarked && (
             <span className="text-yellow-500 ml-2">
               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -98,7 +100,9 @@ export default function NewsList({ category }: NewsListProps) {
             </span>
           )}
         </div>
-        <p className="text-gray-600 text-[14px] mb-1 w-full text-right">{newsItem.summary}</p>
+        <p className="text-gray-600 text-[14px] leading-snug mb-2 w-full text-right line-clamp-2">
+          {newsItem.summary}
+        </p>
         <div className="text-[10px] text-[#F2A359]">{formatDate(newsItem.updatedAt)}</div>
       </div>
     </a>


### PR DESCRIPTION
## 메인페이지 UI 개선

### ✅ 주요 변경 사항
- 카드 제목/내용 2줄 이상일 경우 ... 처리
  - Tailwind line-clamp-2 적용하여 제목(title)과 요약(summary)이 2줄 이상 넘지 않도록 개선
  - 한 줄인 경우에도 오른쪽 정렬 자연스럽게 되도록 w-full text-right 처리

- 시간 포맷팅 개선
  - 기존 updatedAt 값을 formatRelativeTime 함수를 활용해 상대 시간(3일 전 등)으로 표기
  - "전 업데이트" 텍스트를 추가하여 사용자 인식 개선

### 📄 기타
- 카드 내 전체 텍스트 간 줄간격(leading-tight, leading-snug) 및 마진 최적화
- 시간, 제목, 요약 모두 text-right 및 w-full 처리로 통일

### 관련 이슈
#43 