### PR TITLE
fix: 타임 포맷 개선

### DIFF
--- a/frontend/src/pages/PN/utils/dateUtils.ts
+++ b/frontend/src/pages/PN/utils/dateUtils.ts
@@ -14,7 +14,7 @@ export function formatRelativeTime(dateTimeString: string): string {
   const dateUTC = new Date(dateTimeString);
   const nowUTC = new Date(new Date().toISOString()); // 강제 UTC 기준으로 now
 
-  const diff = nowUTC.getTime() - dateUTC.getTime();
+  const diff = nowUTC.getTime() - dateUTC.getTime() - 9 * 60 * 60 * 1000;
 
   const minutes = Math.floor(diff / (1000 * 60));
   const hours = Math.floor(diff / (1000 * 60 * 60));


### PR DESCRIPTION
시간을 계산하는 모듈인 dateUtils.ts를 개선하여
마지막 업데이트로부터 시간이 얼마나 지났는지 정확하게 알 수 있게 함

원인: 브라우저 timezone이 서버의 timezone과 다르다.