### PR TITLE
refactor: 타임라인 카드 제목 잘리지 않게 하기

### DIFF
--- a/frontend/src/pages/PN/PN-003/TimelineCard.tsx
+++ b/frontend/src/pages/PN/PN-003/TimelineCard.tsx
@@ -37,7 +37,7 @@ const TimelineCard: React.FC<TimelineCardProps> = ({
       <div className="relative bg-white rounded-lg shadow-sm p-5 z-20">
         <div className="flex justify-between items-start">
           <div>
-            <h3 className="font-bold text-black truncate max-w-[250px]">{data.title}</h3>
+            <h3 className="font-bold text-black max-w-[250px]">{data.title}</h3>
             <p className="text-xs text-[#F2A359] mt-1">
               {data.startDate} ~ {data.endDate}
             </p>


### PR DESCRIPTION
타임라인 카드 제목이 한 줄이 넘어가면 잘림 -> 자르지 않고 전부 출력

관련 이슈
#51 