### PR TITLE
style: 헤더, 메뉴 사이드바, 모달 창, 토스트 메시지에 적용되는 Tailwind 클래스의 색상 코드 변경

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -32,7 +32,9 @@ export const Header = ({ className: _className }: HeaderProps) => {
       <Link to={ROUTES.MAIN}>
         <Text className={logoClass}>탐나라</Text>
       </Link>
-      <Icon name="MagnifyingGlassIcon" size={24} variant="solid" className={iconClass} />
+      <Link to={ROUTES.SEARCH_RESULTS}>
+        <Icon name="MagnifyingGlassIcon" size={24} variant="solid" className={iconClass} />
+      </Link> 
     </div>
   )
 }

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -12,10 +12,13 @@ type HeaderProps = ReactDivProps & {}
 
 export const Header = ({ className: _className }: HeaderProps) => {
   const className = clsx(
-    'top-0 w-full h-[50px] bg-headerColor',
+    'top-0 w-full h-[48px] bg-headerBackground',
     'flex items-center justify-between px-[20px]',
     _className,
   )
+
+  const iconClass = "text-headerIcon cursor-pointer"
+  const logoClass = "text-2xl font-extrabold cursor-pointer text-headerLogo"
 
   return (
     <div className={className}>
@@ -23,13 +26,13 @@ export const Header = ({ className: _className }: HeaderProps) => {
         name="Bars3Icon"
         size={24}
         variant="solid"
-        className="text-headerIconColor cursor-pointer"
+        className={iconClass}
         onClick={() => useSidebarStore.getState().toggle()}
       />
       <Link to={ROUTES.MAIN}>
-        <Text className="text-2xl font-extrabold cursor-pointer text-headerTextColor">탐나라</Text>
+        <Text className={logoClass}>탐나라</Text>
       </Link>
-      <Icon name="MagnifyingGlassIcon" size={24} variant="solid" className="text-headerIconColor cursor-pointer" />
+      <Icon name="MagnifyingGlassIcon" size={24} variant="solid" className={iconClass} />
     </div>
   )
 }

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -31,16 +31,16 @@ export const Sidebar = () => {
   }, [isOpen, close]);
 
   const className = clsx(
-    'absolute top-0 left-0 h-full w-[240px] bg-menuColor z-50 transition-transform duration-300',
+    'absolute top-0 left-0 h-full w-[240px] bg-menuBackground z-50 transition-transform duration-300',
     isOpen ? 'translate-x-0' : '-translate-x-full'
   );
 
   const iconClass = 'flex justify-end p-4';
-  const lineClass = 'border-t border-lineColor';
+  const lineClass = 'border-t border-ccLine';
   const menuClass = 'relative mx-4 flex flex-col';
-  const titleClass = 'text-menuTitleColor text-2xl font-bold flex flex-col pl-1 pt-10 pb-4';
+  const titleClass = 'text-menuTitle text-2xl font-bold flex flex-col pl-1 pt-10 pb-4';
   const navClass = 'flex flex-col pl-1 pt-6 space-y-4';
-  const navItemClass = 'text-menuItemColor hover:text-menuItemHoverColor text-lg font-medium';
+  const navItemClass = 'text-menuItem hover:text-menuItemHover text-lg font-medium';
   const metaClass = 'absolute bottom-0 left-0 right-0 px-4';
   const metaItemClass = 'flex flex-col pl-1 space-y-1 text-xs font-semithin';
 
@@ -51,14 +51,14 @@ export const Sidebar = () => {
           name="Bars3Icon"
           size={24}
           variant="solid"
-          className="text-menuItemColor cursor-pointer"
+          className="text-menuItem cursor-pointer"
           onClick={close}
         />
       </div>
 
       {isLoggedIn ? (
         <div className={menuClass}>
-          <Text className={titleClass}>마이페이지</Text>
+          <Text className={titleClass}>마이 페이지</Text>
           <div className={lineClass} />
           <nav className={navClass}>
             <Link to={ROUTES.USER_INFO} className={navItemClass} onClick={close}>
@@ -90,12 +90,16 @@ export const Sidebar = () => {
         <div className={clsx(metaItemClass, 'pt-4 pb-8')}>
           <Link
             to={INQUIRY_URL}
-            className="text-menuItemColor hover:text-menuItemHoverColor"
+            className="text-menuItem"
             onClick={close}
           >
             문의하기
           </Link>
-          <Text className="text-metaTextColor">v0.01 25.05.12</Text>
+          <Text
+            className="text-menuMetaText"
+          >
+            v0.01 25.05.12
+          </Text>
         </div>
       </div>
     </div>

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -3,11 +3,11 @@ import clsx from 'clsx';
 import { Input } from '../form/Input';
 
 const backgroundClass = 'fixed inset-0 z-50 bg-myBlack/60 flex items-center justify-center'
-const modalContainerClass = 'bg-modalColor rounded-[10px] w-[320px] p-6 text-center shadow-lg'
+const modalContainerClass = 'bg-modalBg rounded-[10px] w-[320px] p-6 text-center shadow-lg'
 const textWrapperClass = 'mt-2 mb-3 space-y-1'
-const titleClass = 'text-xl font-bold'
-const contentClass = 'text-sm text-modalContentColor'
-const buttonClass = 'px-7 py-1 rounded-md text-modalButtonTextColor font-medium'
+const titleClass = 'text-xl font-bold text-modalTitle'
+const contentClass = 'text-sm text-modalContent'
+const buttonClass = 'px-7 py-1 rounded-md text-modalBtnText font-medium'
 const inputClass = 'mb-5'
 
 type ModalProps = DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> & {
@@ -35,7 +35,7 @@ export const Modal = ({
             onClick={onConfirm}
             className={clsx(
               buttonClass,
-              'bg-modalButtonConfirmColor hover:bg-modalButtonConfirmHoverColor'
+              'bg-modalBtnConfirm hover:bg-modalBtnConfirmHover'
             )}
           >
             확인
@@ -44,7 +44,7 @@ export const Modal = ({
             onClick={onCancel}
             className={clsx(
               buttonClass,
-              'bg-modalButtonCancelColor hover:bg-modalButtonCancelHoverColor'
+              'bg-modalBtnCancel hover:bg-modalBtnCancelHover'
             )}
           >
             취소
@@ -86,11 +86,12 @@ export const InputModal = ({
             disabled={!password.trim()}
             className={clsx(
               buttonClass,
-              'bg-modalButtonConfirmColor hover:bg-modalButtonConfirmHoverColor',
               {
-                'bg-modalButtonInactiveColor cursor-not-allowed': !password.trim(),
+                'bg-modalBtnConfirm hover:bg-modalBtnConfirmHover': password.trim(),
+                'bg-modalBtnInactive': !password.trim(),
               }
             )}
+            
           >
             확인
           </button>
@@ -98,7 +99,7 @@ export const InputModal = ({
             onClick={onCancel}
             className={clsx(
               buttonClass,
-              'bg-modalButtonCancelColor hover:bg-modalButtonCancelHoverColor'
+              'bg-modalBtnCancel hover:bg-modalBtnCancelHover'
             )}
           >
             취소

--- a/frontend/src/components/ui/Toast.tsx
+++ b/frontend/src/components/ui/Toast.tsx
@@ -27,7 +27,7 @@ export const Toast: React.FC<ToastProps> = ({ message, className }) => {
   );
 
   const toastClass = clsx(
-    'bg-toastColor/80 text-toastTextColor rounded-full',
+    'bg-toastBg/80 text-toastText rounded-full',
     'px-4 py-2 text-sm font-light text-left',
     'inline-block w-fit max-w-[350px] whitespace-normal',
     className

--- a/frontend/src/constants/url.ts
+++ b/frontend/src/constants/url.ts
@@ -15,6 +15,7 @@ export const ROUTES = {
   KAKAO_CALLBACK: "/auth/kakao/callback",
   SIGNUP: '/signup',
   USER_INFO: '/user-info',
+  SEARCH_RESULTS: '/search-results',
   NEWS_DETAIL: '/news/:id',
   getNewsDetailPath: (id: number) => `/news/${id}`,
 };

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -28,15 +28,15 @@ export default {
         menuMetaText: '#2A4759',
 
         // CC-003
-        modalColor: '#FFFFFF',
-        modalTitleColor: '#000000',
-        modalContentColor: '#000000',
-        modalButtonTextColor: '#FFFFFF',
-        modalButtonConfirmColor: '#4F4F4F',
-        modalButtonConfirmHoverColor: '#6F6F6F',
-        modalButtonInactiveColor: '#D9D9D9',
-        modalButtonCancelColor: '#9A9A9A',
-        modalButtonCancelHoverColor: '#AAAAAA',
+        modalBg: '#F5F5F5',
+        modalTitle: '#2A4759',
+        modalContent: '#4F4F4F',
+        modalBtnText: '#FFFFFF',
+        modalBtnConfirm: '#F2A359',
+        modalBtnConfirmHover: '#F4C89E',
+        modalBtnInactive: '#F3D7C2',
+        modalBtnCancel: '#2A4759',
+        modalBtnCancelHover: '#577F98',
 
         // CC-004
         toastColor: '#9A9A9A',

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -13,7 +13,7 @@ export default {
         mainBgColor: '#E5E5E5',
 
         // CC
-        lineColor: '#AAAAAA',
+        ccLine: '#DDDDDD',
 
         // CC-001
         headerBackground: '#F2A359',
@@ -21,11 +21,11 @@ export default {
         headerIcon: '#EEEEEE',
 
         // CC-002
-        menuColor: '#F2F2F2',
-        menuTitleColor: '#000000',
-        menuItemColor: '#000000',
-        menuItemHoverColor: '#AAAAAA',
-        menuMetaTextColor: '#6F6F6F',
+        menuBackground: '#EEEEEE',
+        menuTitle: '#2A4759',
+        menuItem: '#2A4759',
+        menuItemHover: '#F2A359',
+        menuMetaText: '#2A4759',
 
         // CC-003
         modalColor: '#FFFFFF',

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -39,8 +39,8 @@ export default {
         modalBtnCancelHover: '#577F98',
 
         // CC-004
-        toastColor: '#9A9A9A',
-        toastTextColor: '#FFFFFF',
+        toastBg: '#2A4759',
+        toastText: '#FFFFFF',
 
         // PU
         puBgColor: '#F9F9F9',

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -16,9 +16,9 @@ export default {
         lineColor: '#AAAAAA',
 
         // CC-001
-        headerColor: '#F2F2F2',
-        headerTextColor: '#000000',
-        headerIconColor: '#000000',
+        headerBackground: '#F2A359',
+        headerLogo: '#EEEEEE',
+        headerIcon: '#EEEEEE',
 
         // CC-002
         menuColor: '#F2F2F2',


### PR DESCRIPTION
## 연관된 이슈
#49 

<br/>

## 작업 내용
- [x] 헤더 세로 길이 수정: 50px -> 48px
- [x] 헤더의 Tailwind 클래스의 색상 코드 변경
- [x] 메뉴 사이드바의 Tailwind 클래스의 색상 코드 변경
- [x] 모달 창의 Tailwind 클래스의 색상 코드 변경
- [x] 토스트 메시지의 Tailwind 클래스의 색상 코드 변경
- [x] 헤더, 메뉴 사이드바, 모달 창, 토스트 메시지의 Tailwind 클래스명 간결화 및 각 컴포넌트에 적용

<br/>

## 결과
### 헤더
<img width="428" alt="image" src="https://github.com/user-attachments/assets/0bc0872f-3b14-4f22-a6b8-c1f02f82cd1c" />

### 메뉴 사이드바
<img width="416" alt="image" src="https://github.com/user-attachments/assets/2246c80e-3bff-469f-a7e5-75be195d78b9" />

### 모달 창
<img width="603" alt="image" src="https://github.com/user-attachments/assets/cb473e37-a8ec-4d8e-97e7-02aac4047da7" />

### 토스트 메시지
<img width="452" alt="image" src="https://github.com/user-attachments/assets/218a078b-273e-4fad-8f38-35c0f077180b" />
