### PR TITLE
[풀스택] [style] 로그인 페이지에 적용되는 Tailwind 클래스의 색상 코드 변경

### DIFF
--- a/frontend/src/components/form/Input.tsx
+++ b/frontend/src/components/form/Input.tsx
@@ -3,13 +3,13 @@ import clsx from "clsx";
 import { Text } from "../ui/Text";
 
 const containerClass = clsx('w-full flex flex-col justify-center');
-const labelClass = clsx('text-base font-semibold text-labelTextColor')
+const labelClass = clsx('text-base font-semibold text-labelText')
 const inputClass = clsx(
-  'h-8 bg-inputBgColor border border-inputBorderColor rounded-[5px]',
-  'focus:outline-none focus:ring-1 focus:ring-inputBorderFocusColor',
-  'inline-block text-sm placeholder-inputPlaceholderColor px-2'
+  'h-8 bg-inputBg border border-inputBorder rounded-[5px]',
+  'focus:outline-none focus:ring-1 focus:ring-inputBorderFocus',
+  'inline-block text-sm placeholder-inputPlaceholder px-2'
 );
-const helperClass = clsx('px-2 text-sm text-helperTextColor leading-snug');
+const helperClass = clsx('px-2 text-sm text-helperText leading-snug');
 
 type InputProps = DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> & {
   labelName?: string;
@@ -32,7 +32,7 @@ export const Input = ({
       {labelName && (
         <Text className={labelClass}>
           {labelName}
-          {required && <span className="text-labelSpanColor">*</span>}
+          {required && <span className="text-labelRequired">*</span>}
         </Text>
       )}
       <input
@@ -79,7 +79,7 @@ export const ButtonInput = ({
       {labelName && (
         <Text className={labelClass}>
           {labelName}
-          {required && <span className="text-labelSpanColor">*</span>}
+          {required && <span className="text-labelRequired">*</span>}
         </Text>
       )}
       <div className={rowClass}>

--- a/frontend/src/components/form/Input.tsx
+++ b/frontend/src/components/form/Input.tsx
@@ -70,8 +70,8 @@ export const ButtonInput = ({
     'flex w-full, space-x-1'
   )
   const buttonClass = clsx(
-    'w-[80px] text-buttonTextColor text-sm rounded-[5px]',
-    isValid ? 'bg-buttonActiveColor' : 'bg-buttonInactiveColor'
+    'w-[80px] text-btnText text-sm rounded-[5px]',
+    isValid ? 'bg-btnActiveBg' : 'bg-btnInactiveBg'
   )
 
   return (

--- a/frontend/src/pages/PU/PU-002/LoginForm.tsx
+++ b/frontend/src/pages/PU/PU-002/LoginForm.tsx
@@ -60,11 +60,11 @@ export const LoginForm = ({}: LoginFormProps) => {
 
   const navigationClass = clsx(
     'w-full justify-center flex flex-row space-x-1',
-    'text-sm text-navigationTextColor'
+    'text-sm text-navText'
   )
 
   const linkClass = clsx(
-    'hover:text-navigationTextHoverColor'
+    'hover:text-navTextHover'
   )
 
   return (

--- a/frontend/src/pages/PU/PU-002/index.tsx
+++ b/frontend/src/pages/PU/PU-002/index.tsx
@@ -3,10 +3,10 @@ import { Wrapper } from "../components/layout/Wrapper";
 import { KaKaoButton } from "../components/ui/Button";
 
 export default function LoginPage() {
-  const lineClass = 'border-t border-lineColor my-5';
+  const lineClass = 'border-t border-ccLine my-5';
 
   return (
-    <div className="wrap bg-puBgColor">
+    <div className="wrap bg-puBg">
       <Wrapper
         title="로그인"
         className="px-8"

--- a/frontend/src/pages/PU/components/layout/Wrapper.tsx
+++ b/frontend/src/pages/PU/components/layout/Wrapper.tsx
@@ -15,12 +15,12 @@ export const Wrapper = ({
 
   const className = clsx(
     'h-fit rounded-xl mx-7 my-16 py-14',
-    'flex flex-col bg-puWrapperColor',
+    'flex flex-col bg-puWrapper',
     _className
   )
 
   const titleClass = clsx(
-    'text-3xl font-extrabold text-puTitleColor',
+    'text-3xl font-extrabold text-puTitle',
     'pb-9 text-center'
   )
 

--- a/frontend/src/pages/PU/components/ui/Button.tsx
+++ b/frontend/src/pages/PU/components/ui/Button.tsx
@@ -10,7 +10,7 @@ type ButtonProps = ReactDivProps & {
   isActive?: boolean
 }
 
-const buttonClass = 'w-full h-9 text-base text-buttonTextColor rounded-[5px]'
+const buttonClass = 'w-full h-9 text-base text-btnText rounded-[5px]'
 
 export const Button = ({
   text,
@@ -20,7 +20,7 @@ export const Button = ({
 
   const className = clsx(
     buttonClass,
-    isActive ? 'bg-buttonActiveColor' : 'bg-buttonInactiveColor',
+    isActive ? 'bg-btnActiveBg' : 'bg-btnInactiveBg',
     _className
   )
 
@@ -44,7 +44,7 @@ export const KaKaoButton = ({
 
   const className = clsx(
     buttonClass,
-    'bg-buttonKakaoColor',
+    'bg-btnKakaoBg text-myBlack',
     _className
   );
 

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -56,10 +56,10 @@ export default {
         metaTextColor: '#4F4F4F',
         inputInactiveText: '#4F4F4F',
 
-        buttonTextColor: '#FFFFFF',
-        buttonInactiveColor: '#D9D9D9',
-        buttonActiveColor: '#4F4F4F',
-        buttonKakaoColor: '#9A9A9A',
+        btnText: '#FFFFFF',
+        btnInactiveBg: '#F3D7C2',
+        btnActiveBg: '#F2A359',
+        btnKakaoBg: '#FEE500',
 
         checkBoxBgColor: '#D9D9D9',
         checkBoxLabelColor: '#000000',

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -42,9 +42,9 @@ export default {
         toastTextColor: '#FFFFFF',
 
         // PU
-        puBgColor: '#F9F9F9',
-        puWrapperColor: '#FFFFFF',
-        puTitleColor: '#000000',
+        puBg: '#FCFAF7',
+        puWrapper: '#FFFFFF',
+        puTitle: '#2A4759',
 
         inputBg: '#F1EFEC',
         inputBorder: '#D4C9BE',
@@ -65,8 +65,8 @@ export default {
         checkBoxLabelColor: '#000000',
         checkBoxMetaTextColor: '#6F6F6F',
 
-        navigationTextColor: '#000000',
-        navigationTextHoverColor: '#A0A0A0',
+        navText: '#2A4759',
+        navTextHover: '#F2A359',
 
         // PN
         pnBgColor: '#FFFFFF',

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -68,9 +68,6 @@ export default {
         navigationTextColor: '#000000',
         navigationTextHoverColor: '#A0A0A0',
 
-        navigationTextColor: '#000000',
-        navigationTextHoverColor: '#A0A0A0',
-
         // PN
         pnBgColor: '#FFFFFF',
         newsCardColor: '#DADADA',

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -13,7 +13,7 @@ export default {
         mainBgColor: '#E5E5E5',
 
         // CC
-        lineColor: '#AAAAAA',
+        ccLine: '#DDDDDD',
 
         // CC-001
         headerColor: '#F2F2F2',
@@ -46,14 +46,14 @@ export default {
         puWrapperColor: '#FFFFFF',
         puTitleColor: '#000000',
 
-        inputBgColor: '#EFEFEF',
-        inputBorderColor: '#DFDFDF',
-        inputBorderFocusColor: '#000000',
-        inputPlaceholderColor: '#9F9F9F',
-        labelTextColor: '#000000',
-        labelSpanColor: '#4F4F4F',
-        helperTextColor: '#808080',
-        metaTextColor: '#4F4F4F',
+        inputBg: '#F1EFEC',
+        inputBorder: '#D4C9BE',
+        inputBorderFocus: '#000000',
+        inputPlaceholder: '#D4C9BE',
+        labelText: '#2A4759',
+        labelRequired: '#F79B72',
+        helperText: '#808080',
+        metaText: '#4F4F4F',
         inputInactiveText: '#4F4F4F',
 
         btnText: '#FFFFFF',


### PR DESCRIPTION
## 연관된 이슈
#49 

<br/>

## 작업 내용
- [x] PU 페이지의 버튼 컴포넌트의 색상 변경
- [x] PU 페이지의 입력창 컴포넌트의 색상 변경
- [x] PU 페이지의 내비게이션 텍스트의 색상 변경
- [x] PU 페이지의 Wrapper 내부 컴포넌트들 색상 변경

<br/>

## 상세 내용
<img width="1207" alt="image" src="https://github.com/user-attachments/assets/a6dc692b-e0fe-4131-b81c-2e43dcfe18ae" />
