### PR TITLE
[풀스택] [style] 누락된 Tailwind 클래스 추가 및 클래스명 변경사항 반영

### DIFF
--- a/frontend/src/components/form/Input.tsx
+++ b/frontend/src/components/form/Input.tsx
@@ -7,7 +7,7 @@ const labelClass = clsx('text-base font-semibold text-labelText')
 const inputClass = clsx(
   'h-8 bg-inputBg border border-inputBorder rounded-[5px]',
   'focus:outline-none focus:ring-1 focus:ring-inputBorderFocus',
-  'inline-block text-sm placeholder-inputPlaceholder px-2'
+  'inline-block text-sm text-myBlack placeholder-inputPlaceholder px-2'
 );
 const helperClass = clsx('px-2 text-sm text-helperText leading-snug');
 

--- a/frontend/src/pages/PU/components/ui/StaticField.tsx
+++ b/frontend/src/pages/PU/components/ui/StaticField.tsx
@@ -13,7 +13,7 @@ export const StaticField = ({
 }: StaticFieldProps) => {
   
   const containerClass = clsx('w-full flex flex-col justify-center', _className);
-  const labelClass = clsx('text-base font-semibold text-labelTextColor')
+  const labelClass = clsx('text-base font-semibold text-labelText')
   const contentClass = clsx('text-base font-light text-myBlack')
   
   return (


### PR DESCRIPTION
## 연관된 이슈
#33 

<br/>

## 작업 내용
- [x] Static Field의 라벨 색상 클래스에 Tailwind 클래스명의 변경 사항 적용
- [x] 입력창의 입력 텍스트에 색상을 명시적으로 지정하여 다크모드에서의 변화 방지

<br/>

## 상세 내용
- '이메일'의 색상 변경 - 남색
- '김철수'의 색상 명시적으로 지정 - 검정
<img width="355" alt="image" src="https://github.com/user-attachments/assets/0c8bb143-3832-4305-ab8a-de775988923a" />
