### PR TITLE
chore: 뉴스 목록 하단 패딩 확장

### DIFF
--- a/frontend/src/pages/PN/PN-001/index.tsx
+++ b/frontend/src/pages/PN/PN-001/index.tsx
@@ -18,7 +18,7 @@ export default function MainPage({ initialCategory = 'all' }: MainPageProps) {
       </div>
       
       {/* 스크롤 가능한 컨테이너 - flex-grow로 나머지 공간 차지 */}
-      <div className="container mx-auto px-4 flex-grow overflow-y-auto pb-6 news-container">
+      <div className="container mx-auto px-4 flex-grow overflow-y-auto pb-20 news-container">
         <NewsList category={selectedCategory} />
       </div>
     </div>


### PR DESCRIPTION
뉴스 목록 컨테이너의 pb를 늘려, 가장 마지막 뉴스도 잘리지 않고 표시된다.