### PR TITLE
[풀스택] [fix] 회원탈퇴 모달창의 입력 컴포넌트 변경

### DIFF
--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -63,8 +63,8 @@ type InputModalProps = ModalProps & {
 
 export const InputModal = ({
   isOpen, title, content, onConfirm, onCancel,
+  text, onTextChange,
   disabled,
-  text, onTextChange
 }: InputModalProps) => {
   if (!isOpen) return null;
 
@@ -88,12 +88,10 @@ export const InputModal = ({
             disabled={disabled}
             className={clsx(
               buttonClass,
-              {
-                'bg-modalBtnConfirm hover:bg-modalBtnConfirmHover': !disabled,
-                'bg-modalBtnInactive': disabled,
-              }
+              disabled ?
+              'bg-modalBtnInactive' :
+              'bg-modalBtnConfirm hover:bg-modalBtnConfirmHover'
             )}
-            
           >
             확인
           </button>


### PR DESCRIPTION
## 연관된 이슈
#67

<br/>

## 작업 내용
- [x] 회원탈퇴 모달창의 입력 컴포넌트의 타입을 password에서 text로 변경하였다.
- [x] 회원탈퇴 모달창의 placeholder 문구를 명시적으로 변경하였다.
- [x] 회원탈퇴 모달창의 확인 버튼의 조건을 외부 함수로 분리하였다.
- [x] 버튼 활성화 여부에 따라 각기 다른 Tailwind 색상 스타일 적용하였다.

<br/>

## 상세 내용
```tsx
export const InputModal = ({
  ...
  text, onTextChange,
  disabled,
}: InputModalProps) => {
  if (!isOpen) return null;

  return (
    <div className={backgroundClass}>
        ...
        <Input
          placeholder='회원탈퇴 문구를 입력하세요.'
          type='text'
          value={text}
          onChange={onTextChange}
        />
        <div className="flex justify-center gap-3">
          <button
              disabled ?
              'bg-modalBtnInactive' :
              'bg-modalBtnConfirm hover:bg-modalBtnConfirmHover'
            )}
          >
            확인
          </button>
          <button
          >
            취소
          </button>
        </div>
      </div>
    </div>
  );
```