### PR TITLE
feat: 댓글에 username 표시

### DIFF
--- a/frontend/src/pages/PN/PN-003/hooks/useComments.ts
+++ b/frontend/src/pages/PN/PN-003/hooks/useComments.ts
@@ -71,7 +71,7 @@ export const useComments = ({
 
           return {
             id: comment.id.toString(),
-            author: isMine ? `${currentUserNickname || '나'}(나)` : `익명 ${comment.userId}`,
+            author: isMine ? `${currentUserNickname || '나'}(나)` : `${comment.username}`,
             content: comment.content,
             createdAt: comment.createdAt,
             isMyComment: isMine,


### PR DESCRIPTION
### 주요 변경사항 

- 기존에 `익명{userId}` 로 표시되던 유저 닉네임을, 실제 닉네임으로 표시