### PR TITLE
fix: 댓글 작성/삭제 후 전체 페이지 새로고침으로 데이터 동기화

### DIFF
--- a/frontend/src/pages/PN/PN-003/hooks/useComments.ts
+++ b/frontend/src/pages/PN/PN-003/hooks/useComments.ts
@@ -158,9 +158,7 @@ export const useComments = ({
         setComments(prev => [...prev, newComment]);
         setCommentText('');
         onToastShow?.('댓글이 등록되었습니다.', 'bottom');
-
-        /* 스크롤 최하단 */
-        setTimeout(() => commentsEndRef.current?.scrollIntoView({ behavior: 'smooth' }), 100);
+        window.location.reload();
       } else {
         onToastShow?.(result.message || '댓글 등록에 실패했습니다.', 'commentInput');
       }
@@ -191,6 +189,7 @@ export const useComments = ({
         /* 성공적으로 삭제됐으면 로컬 상태도 제거 */
         setComments(prev => prev.filter(comment => comment.id !== commentId));
         onToastShow?.('댓글이 삭제되었습니다.', 'bottom');
+        window.location.reload();
       } else {
         const result = await res.json().catch(() => ({ message: '' }));
         onToastShow?.(result.message || '댓글 삭제에 실패했습니다.', 'commentInput');


### PR DESCRIPTION
## fix: 댓글 작성/삭제 후 전체 페이지 새로고침으로 데이터 동기화

### 관련 이슈
#122 

### 주요 변경사항
- `useComments` 훅에서 댓글 작성(`handleSubmitComment`)·삭제(`handleDeleteComment`) 성공 시
`window.location.reload()`을 호출하여 페이지를 즉시 새로고침하도록 수정

### 변경 결과
서버-사이드 데이터와 클라이언트 상태 간 불일치로 인해 발생하던 헤더 사라짐 문제를 해결



### 테스트
- [x] 댓글 작성 후 새로고침 → 작성한 댓글이 정상적으로 표시됨
- [x] 댓글 삭제 후 새로고침 → 삭제한 댓글이 목록에서 사라짐
- [x] 헤더·타임라인 요소가 사라지지 않고 정상 유지됨 (Chrome)