### PR TITLE
feat: 북마크 API 연동 및 상세 페이지 UI 연결

### DIFF
--- a/frontend/src/pages/PN/PN-003/hooks/useTimelineData.ts
+++ b/frontend/src/pages/PN/PN-003/hooks/useTimelineData.ts
@@ -350,44 +350,86 @@ export const useTimelineData = ({ newsId }: UseTimelineDataProps): UseTimelineDa
   }, [fetchNewsData, checkAuth]);
 
   // 북마크 토글 핸들러
-  const handleToggleBookmark = async () => {
-    if (!newsId || !newsData) return Promise.reject(new Error('뉴스 데이터가 없습니다.'));
-    
-    // 숫자 ID 추출
-    // const numericId = newsId.replace(/\D/g, '');
-    
+  const handleToggleBookmark = async (): Promise<void> => {
+    if (!newsId) return Promise.reject(new Error('뉴스 ID가 없습니다.'));
+
+    // 로그인 여부 확인
+    checkAuth();
+    if (!isLoggedIn) {
+      return Promise.reject(new Error('로그인이 필요합니다.'));
+    }
+
+    // access-token 확보
+    const token = localStorage.getItem('token');
+    if (!token) return Promise.reject(new Error('인증 토큰이 없습니다. 다시 로그인해주세요.'));
+
+    const numericId = newsId.replace(/\D/g, '');
+    const safeApiUrl = API_BASE_URL.replace('localhost', '127.0.0.1');
+    const endpoint = `${safeApiUrl}/news/${numericId}/bookmark`;
+
     try {
       setIsUpdating(true);
-      
-      // 실제 API 호출 (백엔드 구현 후 활성화)
-      try {
-        // const response = await axios.post(`${API_BASE_URL}/news/${numericId}/bookmark`, {
-        //   bookmarked: !bookmarked
-        // });
-        
-        // API 성공 여부 확인 (실제 구현 시 주석 해제)
-        // if (response.data.success) {
-        //   setBookmarked(!bookmarked);
-        // } else {
-        //   return Promise.reject(new Error('북마크 업데이트에 실패했습니다.'));
-        // }
-        
-        // 개발 환경 임시 코드 (API 구현 전)
-        console.log('북마크 상태 토글:', !bookmarked);
-        setBookmarked(!bookmarked);
-        
-        // 성공 시 결과 반환
-        return Promise.resolve();
-      } catch (err) {
-        console.error('북마크 API 호출 오류:', err);
-        
-        // 개발 환경에서는 성공으로 처리 (API 구현 전)
-        setBookmarked(!bookmarked);
-        return Promise.resolve();
+
+      // 1) 북마크 추가 (POST)
+      if (!bookmarked) {
+        const res = await axios.post(
+          endpoint,
+          {},
+          {
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${token}`,
+            },
+            timeout: 10_000,
+          },
+        );
+
+        if (res.status === 201 && res.data.success) {
+          setBookmarked(true);
+          return;
+        }
       }
+
+      // 2) 북마크 해제 (DELETE)
+      else {
+        const res = await axios.delete(endpoint, {
+          headers: { Authorization: `Bearer ${token}` },
+          timeout: 10_000,
+        });
+
+        // 204 No Content
+        if (res.status === 204) {
+          setBookmarked(false);
+          return;
+        }
+      }
+
+      // 이외 응답은 모두 예외 처리
+      return Promise.reject(new Error('북마크 처리 중 알 수 없는 오류가 발생했습니다.'));
     } catch (err) {
-      console.error('북마크 토글 오류:', err);
-      return Promise.reject(err);
+      if (axios.isAxiosError(err) && err.response) {
+        const { status, data } = err.response;
+
+        switch (status) {
+          case 400:
+            return Promise.reject(new Error('요청 형식이 올바르지 않습니다.'));
+          case 401:
+            useAuthStore.getState().logout();
+            return Promise.reject(new Error('인증되지 않은 사용자입니다. 다시 로그인해주세요.'));
+          case 404:
+            return Promise.reject(new Error('요청하신 뉴스를 찾을 수 없습니다.'));
+          case 405:
+            return Promise.reject(new Error('허용되지 않은 HTTP 메서드입니다.'));
+          case 409:
+            return Promise.reject(new Error('이미 북마크된 뉴스입니다.'));
+          case 429:
+            return Promise.reject(new Error('요청이 너무 많습니다. 잠시 후 다시 시도해주세요.'));
+          default:
+            return Promise.reject(new Error(data?.message || '서버 오류가 발생했습니다.'));
+        }
+      }
+
+      return Promise.reject(new Error('북마크 처리 중 네트워크 오류가 발생했습니다.'));
     } finally {
       setIsUpdating(false);
     }

--- a/frontend/src/pages/PN/PN-003/index.tsx
+++ b/frontend/src/pages/PN/PN-003/index.tsx
@@ -102,12 +102,10 @@ export default function NewsDetail() {
   // 북마크 토글 핸들러 (토스트 메시지 추가)
   const onToggleBookmark = async () => {
     try {
-      // await handleToggleBookmark();
-      // showToastMessage(bookmarked ? '북마크가 해제되었습니다.' : '북마크에 추가되었습니다.');
-      showToastMessage('업데이트 예정입니다.');
+      await handleToggleBookmark();
+      showToastMessage(bookmarked ? '북마크가 해제되었습니다.' : '북마크에 추가되었습니다.');
     } catch (err) {
-      // showToastMessage('북마크 업데이트에 실패했습니다.');
-      showToastMessage('업데이트 예정입니다.');
+      showToastMessage((err as Error).message);
     }
   };
 

--- a/frontend/src/pages/PN/PN-003/index.tsx
+++ b/frontend/src/pages/PN/PN-003/index.tsx
@@ -69,8 +69,8 @@ export default function NewsDetail() {
     toggleSources,
     isUpdating,
     isUpdateAvailable,
-    // handleToggleBookmark,
-    // handleShare,
+    handleToggleBookmark,
+    handleShare,
     handleTimelineUpdate,
     formattedTimeline
   } = useTimelineData({ newsId });
@@ -114,12 +114,10 @@ export default function NewsDetail() {
   // 공유하기 핸들러 (토스트 메시지 추가)
   const onShare = async () => {
     try {
-      // await handleShare();
-      // showToastMessage('URL이 복사되었습니다!');
-      showToastMessage('업데이트 예정입니다.');
+      await handleShare();
+      showToastMessage('URL이 복사되었습니다!');
     } catch (err) {
-      // showToastMessage('URL 복사에 실패했습니다.');
-      showToastMessage('업데이트 예정입니다.');
+      showToastMessage('URL 복사에 실패했습니다.');
     }
   };
 


### PR DESCRIPTION
## feat: 북마크 API 연동 및 상세 페이지 UI 연결

### 관련 이슈
#126 

### 개요
- 상세 타임라인 페이지(PN-003)에서 **북마크 추가 / 해제 기능**을 실제 API 스펙(POST / DELETE `/news/{newsId}/bookmark`)에 맞춰 구현
- 성공·실패 상황에 따른 토스트 메시지 및 인증/권한 예외 처리

---

#### 주요 변경 사항
| 파일 | 변경 내용 |
|------|-----------|
| **`useTimelineData.ts`** | • `handleToggleBookmark`를 API 연동 로직으로 전면 교체<br>• 로그인 여부·토큰 존재 여부 검증<br>• POST(201), DELETE(204) 분기 처리 및 상세 status code 매핑<br>• `isUpdating` 스피너 관리 일원화 |
| **`PN-003/index.tsx`** | • `handleToggleBookmark`, `handleShare` 직접 호출하도록 수정<br>• 각 액션 성공/실패 시 토스트 메시지 표시<br>• 임시 “업데이트 예정입니다.” 메시지 삭제 |

---

#### 테스트 방법
1. **로그인** 후 뉴스 상세 페이지 진입  
2. 북마크 아이콘 클릭  
   - 최초 클릭 → 201 Created, 아이콘 활성화, “북마크에 추가되었습니다.” 토스트  
   - 재클릭    → 204 No Content, 아이콘 비활성화, “북마크가 해제되었습니다.” 토스트  
3. 인증 만료 시 401 응답 → 자동 로그아웃 및 에러 토스트  
4. 네트워크 차단 등으로 실패 시 “북마크 처리 중 네트워크 오류가 발생했습니다.” 토스트 확인

---

#### 기타
- `localhost` → `127.0.0.1` 치환으로 iOS CORS 문제 예방
- 타임아웃 10 초 설정 (필요 시 조정)
- 추후 **optimistic UI**(클릭 즉시 UI 변경 후 실패 시 롤백) 검토
