### PR TITLE
fix: 알림 카드 클릭 시 경로 소문자 처리 및 ID 미존재 시 기본 경로로 이동

### DIFF
--- a/frontend/src/components/layout/SidebarAlarm/AlarmCard.tsx
+++ b/frontend/src/components/layout/SidebarAlarm/AlarmCard.tsx
@@ -27,8 +27,8 @@ export const AlarmCard = ({
   const navigate = useNavigate()
 
   const handleNavigate = () => {
-    if (targetType && targetId !== undefined) {
-      navigate(`/${targetType}/${targetId}`)
+    if (targetType) {
+      navigate(targetId != null ? `/${targetType.toLowerCase()}/${targetId}` : `/${targetType.toLowerCase()}`)
     }
   }
 


### PR DESCRIPTION
## 연관된 이슈
#165 

<br/>

## 작업 내용
- [x] 알림 카드 클릭 시 경로 소문자 처리
- [x] `targetId` 미존재 시 기본 경로(`/targetType`)로 이동

<br/>

## 상세 내용
### 알림 카드 클릭 시 경로 소문자 처리 및 ID 미존재 시 기본 경로로 이동
- **작업한 파일:** `/src/components/layout/SidebarAlarm/AlarmCard.tsx`
- **작업 내용:**
   - 알림 카드 클릭 시 경로 소문자 처리
   - `targetType`의 존재 여부, `targetId`의 존재 여부에 따른 이동 경로 분기 처리
```tsx
const handleNavigate = () => {
  if (targetType) {
    navigate(targetId != null ? `/${targetType.toLowerCase()}/${targetId}` : `/${targetType.toLowerCase()}`)
  }
}
```