### PR TITLE
feat: 뉴스 생성 로직 개선 및 뉴스 카드 UI 기능 통합 적용

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,3 +1,3 @@
 .wrap {
-  @apply w-full h-full;
+  @apply w-full h-full bg-pageBg overflow-y-auto;
 }

--- a/frontend/src/constants/PN/SearchResultMessage.ts
+++ b/frontend/src/constants/PN/SearchResultMessage.ts
@@ -4,5 +4,6 @@ export const SearchResultMessage = {
   CREATE_NEWS_BTN_LOADING: '뉴스 생성 중',
   CREATE_NEWS_BTN_LOGOUT: `로그인하고\n타임라인 생성하기`,
   CREATE_NEWS_SUCCESS: '뉴스를 성공적으로 생성하였습니다.',
+  CREATE_NEWS_TIMEOUT: '뉴스 생성 요청이 시간 초과로 실패했습니다.',
   CREATE_NEWS_FAIL: '뉴스 생성 중 오류가 발생했습니다.',
 }

--- a/frontend/src/constants/url.ts
+++ b/frontend/src/constants/url.ts
@@ -54,7 +54,7 @@ export const ENDPOINTS = {
     }
     return `/news/search?${params.toString()}`
   },
-  BOOKMARK: '/news/:id/bookmark',
+  BOOKMARK: (id: string) => `/news/${id}/bookmark`,
   COMMENT: '/news/:id/comments',
   POLL_FETCH: `/polls`,
   POLL_SUBMIT: `/polls/vote`,

--- a/frontend/src/lib/axios.ts
+++ b/frontend/src/lib/axios.ts
@@ -7,7 +7,7 @@ export const axiosInstance = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
-  timeout: 500000,
+  timeout: 0,
 });
 
 axiosInstance.interceptors.request.use((config) => {

--- a/frontend/src/pages/PN/PN-001/index.tsx
+++ b/frontend/src/pages/PN/PN-001/index.tsx
@@ -11,7 +11,7 @@ export default function MainPage({ initialCategory = 'all' }: MainPageProps) {
   const [selectedCategory, setSelectedCategory] = React.useState(initialCategory);
 
   return (
-    <div className="h-screen bg-[#FDFAF7] flex flex-col">
+    <div className="wrap">
       <div className="container mx-auto px-4 pt-6 pb-4 flex-shrink-0">
         <Banner />
         <Category onCategoryChange={setSelectedCategory} />

--- a/frontend/src/pages/PN/PN-002/index.tsx
+++ b/frontend/src/pages/PN/PN-002/index.tsx
@@ -30,7 +30,7 @@ export default function SearchResultPage() {
   }, [tags])
 
   return (
-    <div className="wrap bg-pvBg overflow-y-auto">
+    <div className="wrap">
       <CreateNewsBtnBox
         isButtonActive={isButtonActive}
         isLoading={isLoading}

--- a/frontend/src/pages/PN/PN-002/useSearchResultLogic.tsx
+++ b/frontend/src/pages/PN/PN-002/useSearchResultLogic.tsx
@@ -44,9 +44,10 @@ export const useSearchResultLogic = ({ setToastMessage }: SearchResultLogicProps
       const res = await postData(ENDPOINTS.NEWS, { keywords: tags })
       if (res.location) {
         navigate(res.location)
+        setToastMessage(res.message || SearchResultMessage.CREATE_NEWS_SUCCESS)
       } else {
         setTimeout(() => {
-          setToastMessage(res.message || SearchResultMessage.CREATE_NEWS_SUCCESS)
+          setToastMessage(res?.message || SearchResultMessage.CREATE_NEWS_TIMEOUT)
         }, 0)
       }
     } catch (e: any) {

--- a/frontend/src/pages/PN/components/layout/NewsCard.tsx
+++ b/frontend/src/pages/PN/components/layout/NewsCard.tsx
@@ -1,11 +1,14 @@
-import type { DetailedHTMLProps, HTMLAttributes } from 'react'
-import clsx from 'clsx'
-import { formatRelativeTime } from '../../utils/formatRelativeTime'
+import { useState, type DetailedHTMLProps, type HTMLAttributes } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { ROUTES } from '@/constants/url'
+import { formatRelativeTime } from '../../utils/formatRelativeTime'
+import { ROUTES, ENDPOINTS } from '@/constants/url'
+import { Icon } from '@/components/ui/Icon'
+import { axiosInstance } from '@/lib/axios'
+import { useAuthStore } from '@/stores/useAuthStore'
+import clsx from 'clsx'
 
 type ReactDivProps = DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>
-type NewsCardrops = ReactDivProps & {
+type NewsCardProps = ReactDivProps & {
   id: string
   title: string
   summary: string
@@ -14,29 +17,67 @@ type NewsCardrops = ReactDivProps & {
   bookmarked: boolean
 }
 
-export const NewsCard = ({ id, title, summary, image, updatedAt, bookmarked, className: _className }: NewsCardrops) => {
+export const NewsCard = ({
+  id,
+  title,
+  summary,
+  image,
+  updatedAt,
+  bookmarked: initialBookmarked,
+  className: _className,
+}: NewsCardProps) => {
   const navigate = useNavigate()
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn)
+  const [bookmarked, setBookmarked] = useState(initialBookmarked)
+
+  const handleBookmark = async () => {
+    if (!isLoggedIn) return
+    try {
+      if (bookmarked) {
+        await axiosInstance.delete(ENDPOINTS.BOOKMARK(id))
+        setBookmarked(false)
+      } else {
+        await axiosInstance.post(ENDPOINTS.BOOKMARK(id))
+        setBookmarked(true)
+      }
+    } catch (e) {
+      console.error('북마크 처리 실패:', e)
+    }
+  }
 
   const wrapperClass =
-    'flex flex-row items-center w-full overflow-hidden bg-newsCardBg border-b border-b-newsCardBorder cursor-pointer p-4 gap-4'
-
-  const contentBoxClass = 'h-[120px] flex-grow flex flex-col justify-center gap-2'
-  const titleClass = 'text-lg font-semibold text-newsCardTitle leading-tight line-clamp-2'
-  const summaryClass = 'text-sm text-newsCardSummary leading-snug line-clamp-2'
-  const timeClass = 'w-full text-xs text-newsCardTime text-right'
-
-  const imageBoxClass = 'flex-shrink-0 w-[120px] h-[120px] flex items-center justify-center'
+    'flex flex-row items-center w-full overflow-hidden bg-newsCardBg border-b border-b-newsCardBorder p-4 gap-4'
+  const imageBoxClass = 'flex-shrink-0 w-[120px] h-[120px] flex items-center justify-center cursor-pointer'
   const imageClass = 'w-full h-full object-cover rounded-[10px]'
 
+  const contentBoxClass = 'h-[120px] flex-grow flex flex-col justify-center gap-2'
+  const titleClass = 'text-lg font-semibold text-newsCardTitle leading-tight line-clamp-2 cursor-pointer'
+  const summaryClass = 'text-sm text-newsCardSummary leading-snug line-clamp-2'
+
+  const metaTextClass = 'flex justify-center items-center gap-2'
+  const timeClass = 'w-full text-xs text-newsCardTime text-right'
+  const iconClass = clsx('text-newsCardIcon', isLoggedIn && 'cursor-pointer')
+
   return (
-    <div className={wrapperClass} onClick={() => navigate(ROUTES.getNewsDetailPath(id))}>
+    <div className={wrapperClass}>
       <div className={imageBoxClass}>
         <img src={image} alt={title} className={imageClass} />
       </div>
       <div className={contentBoxClass}>
-        <h3 className={titleClass}>{title}</h3>
+        <h3 className={titleClass} onClick={() => navigate(ROUTES.getNewsDetailPath(id))}>
+          {title}
+        </h3>
         <div className={summaryClass}>{summary}</div>
-        <div className={timeClass}>{formatRelativeTime(updatedAt)}</div>
+        <div className={metaTextClass}>
+          <div className={timeClass}>{formatRelativeTime(updatedAt)}</div>
+          <Icon
+            name="BookmarkIcon"
+            size={18}
+            variant={bookmarked ? 'solid' : 'outline'}
+            className={iconClass}
+            onClick={handleBookmark}
+          />
+        </div>
       </div>
     </div>
   )

--- a/frontend/src/pages/PN/components/layout/NewsCardListBox.tsx
+++ b/frontend/src/pages/PN/components/layout/NewsCardListBox.tsx
@@ -8,12 +8,11 @@ type SearchResultBoxProps = DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HT
 }
 
 export default function NewsCardListBox({ news, noNewsText }: SearchResultBoxProps) {
-  const wrapperClass = 'h-full'
   const metaTextBoxClass = 'flex justify-center items-start min-h-screen pt-[30vh]'
   const metaTextClass = 'text-sm text-center text-gray-500 justify-center items-center'
 
   return (
-    <div className={wrapperClass}>
+    <div>
       {news.length === 0 && (
         <div className={metaTextBoxClass}>
           <div className={metaTextClass}>{noNewsText}</div>

--- a/frontend/src/pages/PU/PU-001/index.tsx
+++ b/frontend/src/pages/PU/PU-001/index.tsx
@@ -6,7 +6,7 @@ export default function SignUpPage() {
   const lineClass = 'border-t border-ccLine my-5'
 
   return (
-    <div className="wrap bg-puBg overflow-y-auto">
+    <div className="wrap">
       <Wrapper title="회원가입" className="px-8">
         <SignUpForm />
         <div className={lineClass} />

--- a/frontend/src/pages/PU/PU-002-01/index.tsx
+++ b/frontend/src/pages/PU/PU-002-01/index.tsx
@@ -4,7 +4,7 @@ import { FindPasswordForm } from './FindPasswordForm'
 
 export default function FindPasswordPage() {
   return (
-    <div className="wrap bg-puBg">
+    <div className="wrap">
       <Wrapper title={FindPasswordMessage.TITLE} content={FindPasswordMessage.CONTENT} className="px-8">
         <FindPasswordForm />
       </Wrapper>

--- a/frontend/src/pages/PU/PU-002-02/index.tsx
+++ b/frontend/src/pages/PU/PU-002-02/index.tsx
@@ -6,7 +6,7 @@ import { useAuthStore } from '@/stores/useAuthStore'
 export default function ResetPasswordPage() {
   const title = ResetPasswordMessage.TITLE(useAuthStore((state) => state.isLoggedIn))
   return (
-    <div className="wrap bg-puBg">
+    <div className="wrap">
       <Wrapper title={title} className="px-8">
         <ResetPasswordForm />
       </Wrapper>

--- a/frontend/src/pages/PU/PU-002/index.tsx
+++ b/frontend/src/pages/PU/PU-002/index.tsx
@@ -7,7 +7,7 @@ export default function LoginPage() {
   const lineClass = 'border-t border-ccLine my-5'
 
   return (
-    <div className="wrap bg-puBg">
+    <div className="wrap">
       <Wrapper title={LoginMessage.TITLE} className="px-8">
         <LoginForm />
         <div className={lineClass} />

--- a/frontend/src/pages/PU/PU-003/index.tsx
+++ b/frontend/src/pages/PU/PU-003/index.tsx
@@ -4,7 +4,7 @@ import { UserInfoForm } from './UserInfoForm'
 
 export default function UserInfoPage() {
   return (
-    <div className="wrap bg-puBg">
+    <div className="wrap">
       <Wrapper title={UserInfoMessage.TITLE} className="px-8">
         <UserInfoForm />
       </Wrapper>

--- a/frontend/src/pages/PV/PV-001/index.tsx
+++ b/frontend/src/pages/PV/PV-001/index.tsx
@@ -10,7 +10,7 @@ export default function PollPage() {
   const logic = usePollLogic({ setToastMessage })
 
   return (
-    <div className="wrap bg-pvBg">
+    <div className="wrap">
       <Wrapper title={PollMessage.TITLE(logic.title)} content={PollMessage.CONTENT(logic.endAt)} className="px-8">
         <PollForm
           handleSubmit={logic.handleSubmit}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -109,6 +109,7 @@ export default {
         newsCardTitle: '#2A4759',
         newsCardSummary: '#717171',
         newsCardTime: '#F2A359',
+        newsCardIcon: '#577F98',
         createNewsBtnBoxBorder: '#EEEEEE',
       },
     },

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -11,6 +11,7 @@ export default {
         myWhite: '#FFFFFF',
         myBlack: '#000000',
         mainBgColor: '#E5E5E5',
+        pageBg: '#FCFAF7',
 
         // CC
         ccLine: '#DDDDDD',
@@ -63,7 +64,6 @@ export default {
         alarmCardDate: '#4F4F4F',
 
         // PU
-        puBg: '#FCFAF7',
         puWrapper: '#FFFFFF',
         puTitle: '#2A4759',
 
@@ -90,7 +90,6 @@ export default {
         navTextHover: '#F2A359',
 
         // PV
-        pvBg: '#FCFAF7',
         pollBoxBorder: '#DADADA',
         pollOptionBg: '#F1EFEC',
         pollOptionSelectBg: '#E3D8CE',


### PR DESCRIPTION
## 연관된 이슈
#163 #167 #168 #169

<br/>

## 작업 내용
- [x] 뉴스 생성 시 타임아웃 토스트 메시지 분기 처리
- [x] 응답 대기 시간을 무제한으로 설정
- [x] 공통 페이지 css를 `.wrap` 클래스에 정의하고 적용
- [x] 뉴스 카드 컴포넌트에 북마크 아이콘 및 API 연동 추가
- [x] 뉴스 카드 목록 박스 컴포넌트의 height 관련 CSS 추가

<br/>

## 상세 내용
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/e9c004f4-7aa1-42ea-8eb5-f7a1f92d9a24" />
