### PR TITLE
fix: 닉네임 중복 확인 로직 제거로 인한 빌드 오류 해결

### DIFF
--- a/frontend/src/pages/PU/PU-001/SignUpForm.tsx
+++ b/frontend/src/pages/PU/PU-001/SignUpForm.tsx
@@ -32,7 +32,6 @@ export const SignUpForm = ({}: SignUpFormProps) => {
     checkedPrivacy,
     setCheckedPrivacy,
     checkEmailDuplicate,
-    checkNameDuplicate,
     codeValid,
     errors,
     isButtonActive,
@@ -122,7 +121,6 @@ export const SignUpForm = ({}: SignUpFormProps) => {
         value={name}
         maxLength={10}
         onChange={(e) => setName(e.target.value)}
-        onBlur={checkNameDuplicate}
         helperText={errors.name}
       />
       <CheckSection

--- a/frontend/src/pages/PU/PU-001/SignUpLogic.ts
+++ b/frontend/src/pages/PU/PU-001/SignUpLogic.ts
@@ -83,15 +83,6 @@ export const useSignUpLogic = () => {
       setEmailAvailable,
     )
 
-  const checkNameDuplicate = () =>
-    checkDuplicate(
-      name,
-      (val) => getData(ENDPOINTS.CHECK_NAME(val)),
-      'name',
-      '이미 사용 중인 닉네임입니다.',
-      setNameAvailable,
-    )
-
   const sendVerificationCode = async () => {
     try {
       const res = await postData(ENDPOINTS.SEND_CODE, { email })
@@ -171,7 +162,6 @@ export const useSignUpLogic = () => {
     checkedPrivacy,
     setCheckedPrivacy,
     checkEmailDuplicate,
-    checkNameDuplicate,
     codeValid,
     errors,
     isButtonActive,


### PR DESCRIPTION
## 작업 내용
- [ ] `useSignUpLogic` 훅에서 닉네임 중복 확인 요청 메서드 제거
- [ ] `useSignUpLogic` 훅에서 닉네임 중복 확인 메서드 반환값 제거
