### PR TITLE
fix: 회원탈퇴 요청 HTTP 메서드를 PATCH로 변경하고, form 컴포넌트의 로직을 훅으로 분리

### DIFF
--- a/frontend/src/pages/PU/PU-003/UserInfoForm.tsx
+++ b/frontend/src/pages/PU/PU-003/UserInfoForm.tsx
@@ -1,14 +1,9 @@
 import { useState, type DetailedHTMLProps, type HTMLAttributes } from 'react'
-import clsx from 'clsx'
-import { Input } from '@/components/form/Input'
 import { Button } from '../components/ui/Button'
-import { Link } from 'react-router-dom'
 import { Text } from '@/components/ui/Text'
 import { StaticField } from '../components/ui/StaticField'
 import { InputModal } from '@/components/ui/Modal'
 import { useUserInfoLogic } from './useUserInfoLogic'
-import { useRequestStore } from '@/stores/useRequestStore'
-import { ENDPOINTS, ROUTES } from '@/constants/url'
 import { Toast } from '@/components/ui/Toast'
 import { UserInfoMessage } from '@/constants/PU/userInfoMessage'
 import { NavigationLink } from '@/constants/navigationLink'
@@ -26,41 +21,20 @@ export const UserInfoForm = ({}: UserInfoFormProps) => {
     name,
     setName,
     isInputModalOpen,
-    setIsInputModalOpen,
     errors,
     isButtonActive,
     handleSubmit,
+    handleDeleteAccount,
+    handleConfirmDelete,
+    handleCancelDelete
   } = useUserInfoLogic({ setToastMessage })
-
-  const { deleteData } = useRequestStore()
 
   const disabled = !(text.trim() === UserInfoMessage.WITHDRAW_VALID_INPUT)
 
-  const handleDeleteAccount = () => {
-    setText('')
-    setIsInputModalOpen(true)
-  }
-
-  const handleConfirmDelete = async () => {
-    setIsInputModalOpen(false)
-    try {
-      const res = await deleteData(ENDPOINTS.USER_WITHDRAW)
-      if (res?.success) {
-        setToastMessage(UserInfoMessage.WITHDRAW_SUCCESS)
-      }
-    } catch (err) {
-      console.error('유저 탈퇴 실패', err)
-    }
-  }
-
-  const handleCancelDelete = () => {
-    setIsInputModalOpen(false)
-  }
-
-  const formClass = clsx('w-full flex flex-col justify-center', 'space-y-3')
-  const buttonClass = clsx('flex flex-col pt-8 space-y-1')
-  const navigationClass = clsx('w-full justify-center flex flex-row space-x-1', 'text-sm text-navText')
-  const linkClass = clsx('hover:text-navTextHover')
+  const formClass = 'w-full flex flex-col justify-center space-y-3'
+  const buttonClass = 'flex flex-col pt-8 space-y-1'
+  const navigationClass = 'w-full justify-center flex flex-row space-x-1 text-sm text-navText'
+  const linkClass = 'hover:text-navTextHover'
 
   return (
     <>

--- a/frontend/src/pages/PU/PU-003/useUserInfoLogic.ts
+++ b/frontend/src/pages/PU/PU-003/useUserInfoLogic.ts
@@ -20,7 +20,7 @@ export const useUserInfoLogic = ({ setToastMessage }: UserInfoLogicProps) => {
   const [isButtonActive, setIsButtonActive] = useState(false)
   const [isInputModalOpen, setIsInputModalOpen] = useState(false)
 
-  const { isLoggedIn, username, setUsername } = useAuthStore()
+  const { logout, isLoggedIn, username, setUsername } = useAuthStore()
   const { getData, patchData } = useRequestStore()
   const navigate = useNavigate()
 
@@ -76,6 +76,28 @@ export const useUserInfoLogic = ({ setToastMessage }: UserInfoLogicProps) => {
     }
   }
 
+  const handleDeleteAccount = () => {
+    setText('')
+    setIsInputModalOpen(true)
+  }
+
+  const handleConfirmDelete = async () => {
+    setIsInputModalOpen(false)
+    try {
+      const res = await patchData(ENDPOINTS.USER_WITHDRAW)
+      if (res?.success) {
+        logout()
+        setToastMessage(UserInfoMessage.WITHDRAW_SUCCESS)
+      }
+    } catch (err) {
+      console.error('유저 탈퇴 실패', err)
+    }
+  }
+
+  const handleCancelDelete = () => {
+    setIsInputModalOpen(false)
+  }
+
   return {
     email,
     text,
@@ -85,7 +107,9 @@ export const useUserInfoLogic = ({ setToastMessage }: UserInfoLogicProps) => {
     errors,
     isButtonActive,
     handleSubmit,
+    handleDeleteAccount,
+    handleConfirmDelete,
+    handleCancelDelete,
     isInputModalOpen,
-    setIsInputModalOpen,
   }
 }


### PR DESCRIPTION
## 연관된 이슈
#216 

<br/>

## 작업 내용
- [x] 회원탈퇴 요청 HTTP 메서드를 `PATCH`로 변경
- [x] UserInfoForm 컴포넌트의 로직을 useUserInfoLogic 훅으로 분리

<br/>

## 상세 내용
<img width="1604" alt="image" src="https://github.com/user-attachments/assets/c653f210-3647-4c4f-ba0c-ad3d2e41db07" />
