### PR TITLE
feat: 메인 페이지의 일반 뉴스 카드 목록 자동 갱신을 위한 폴링 기능 추가

### DIFF
--- a/frontend/src/components/layout/SidebarMenu/SidebarMenu.tsx
+++ b/frontend/src/components/layout/SidebarMenu/SidebarMenu.tsx
@@ -50,7 +50,7 @@ export const SidebarMenu = () => {
           <Link to={INQUIRY_URL} className="text-menuItem" onClick={close} target="_blank" rel="noopener noreferrer">
             문의하기
           </Link>
-          <Text className="text-menuMetaText">v3.0.0 25.07.07</Text>
+          <Text className="text-menuMetaText">v3.1.1 25.07.08</Text>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/PN/PN-001/hooks/useFetchNormal.ts
+++ b/frontend/src/pages/PN/PN-001/hooks/useFetchNormal.ts
@@ -38,7 +38,10 @@ export const useFetchNormal = () => {
   )
 
   useEffect(() => {
-    fetchNews()
+    const interval = setInterval(() => {
+      fetchNews()
+    }, 5000)
+    return () => clearInterval(interval)
   }, [fetchNews])
 
   return {


### PR DESCRIPTION
## 연관된 이슈
#237 

<br/>

## 작업 내용
- [x] 메인 페이지의 일반 뉴스 카드 목록 조회에 폴링 기능(5초) 추가
- [x] 메뉴 사이드바의 버전을 최신(v3.1.1 07.08)으로 적용

<br/>

## 상세 내용
### 일반 뉴스 카드 목록 조회에 폴링 기능 추가
- **작업한 파일:** `src/pages/PN/PN-001/hooks/usesFetchNormal.ts`
- **작업 내용**: 일반 뉴스 카드 목록 조회에 폴링 기능 추가
```ts
useEffect(() => {
  const interval = setInterval(() => {
    fetchNews()
  }, 5000)
  return () => clearInterval(interval)
}, [fetchNews])
```