### PR TITLE
refactor: 로딩 페이지, 메인 페이지 캐러셀, 뉴스 상세 페이지 썸네일 레이아웃 개선

### DIFF
--- a/frontend/src/components/layout/SidebarMenu/SidebarMenu.tsx
+++ b/frontend/src/components/layout/SidebarMenu/SidebarMenu.tsx
@@ -50,7 +50,7 @@ export const SidebarMenu = () => {
           <Link to={INQUIRY_URL} className="text-menuItem" onClick={close} target="_blank" rel="noopener noreferrer">
             문의하기
           </Link>
-          <Text className="text-menuMetaText">v3.1.1 25.07.08</Text>
+          <Text className="text-menuMetaText">v3.2.3 25.07.09</Text>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/PL/LoadingContainer.tsx
+++ b/frontend/src/pages/PL/LoadingContainer.tsx
@@ -2,7 +2,7 @@ import { TamnaraIcon } from '@/assets'
 import { useTypingLoadingText } from './useTypingLoadingText'
 
 export const LoadingContainer = () => {
-  const iconContainerClass = 'flex flex-col h-full justify-center items-center gap-2'
+  const iconContainerClass = 'flex flex-col h-full justify-start items-center gap-2 mt-80'
   const iconClass = 'w-20'
   const textClass = 'text-lg font-semibold text-point'
 

--- a/frontend/src/pages/PN/PN-001/Carousel.tsx
+++ b/frontend/src/pages/PN/PN-001/Carousel.tsx
@@ -17,7 +17,7 @@ export const Carousel = () => {
 
   const wrapperClass = 'w-full h-[200px] bg-carouselBg rounded-[5px] flex items-center justify-center cursor-pointer'
   const metaTextClass = 'text-carouselInactive text-center text-sm'
-  const loadingClass = 'animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-carouselInactive'
+  const loadingClass = 'animate-spin rounded-full h-12 w-12 border-4 border-ccLine border-t-point'
   const titleWrapperClass = 'absolute bottom-0 left-0 right-0 h-1/2 bg-gradient-to-t from-myBlack/80 to-transparent'
   const titleClass = 'absolute bottom-4 text-myWhite text-2xl font-semibold line-clamp-1 px-4'
   const imageClass = 'w-full h-full object-cover'

--- a/frontend/src/pages/PN/PN-003/Thumbnail.tsx
+++ b/frontend/src/pages/PN/PN-003/Thumbnail.tsx
@@ -8,12 +8,14 @@ type ThumbnailProps = ReactDivProps & {
 }
 
 export const Thumbnail = ({ image, title }: ThumbnailProps) => {
-  const wrapperClass = 'flex overflow-hidden'
-  const imageClass = 'w-full h-[200px] object-contain'
+  const wrapperClass = 'w-full aspect-[5/3] overflow-hidden'
+  const imageClass = 'w-full h-full object-cover'
 
   return (
-    <div className={wrapperClass}>
-      <img src={image || TamnaraDefaultImg} alt={title} className={imageClass} />
+    <div>
+      <div className={wrapperClass}>
+        <img src={image || TamnaraDefaultImg} alt={title} className={imageClass} />
+      </div>
     </div>
   )
 }

--- a/frontend/src/pages/PN/PN-003/index.tsx
+++ b/frontend/src/pages/PN/PN-003/index.tsx
@@ -53,7 +53,7 @@ export default function NewsDetail() {
   }
 
   return (
-    <div className="flex flex-col w-full h-screen scrollbar-hide overflow-y-auto">
+    <div className="flex flex-col w-full h-screen overflow-y-auto scrollbar-hide">
       <TimelineHeader
         isLoggedIn={isLoggedIn}
         title={news.title}
@@ -62,9 +62,7 @@ export default function NewsDetail() {
         onToggleBookmark={handleBookmark}
         onShare={handleShare}
       />
-      <div className="mt-4">
-        <Thumbnail title={news.title} image={news.image} />
-      </div>
+      <Thumbnail title={news.title} image={news.image} />
       {news.category !== 'KTB' && (
         <UpdateButtonBox
           isUpdating={isUpdating}


### PR DESCRIPTION
## 연관된 이슈
#250 

<br/>

## 작업 내용
- [x] 로딩 페이지의 로딩 컨테이너 위치를 화면 중앙보다 위로 개선
- [x] 뉴스 상세 페이지 썸네일 이미지를 꽉 차게(`object-cover`), 비율을 항상 5:3(`aspect-[5/3]`)으로 변경
- [x] 뉴스 상세 페이지에서 헤더와 썸네일 사이 간격 제거
- [x] 메일 페이지 캐러셀의 로딩 디자인 개선
- [x] 메뉴 사이드바의 메뉴 상수 버전 업데이트(v3.2.3)

<br/>

## 상세 내용
### 로딩 페이지
![image](https://github.com/user-attachments/assets/e82d6b0c-1c43-40de-b8a1-9d20b1675637)

<br/>

### 뉴스 상세 페이지
![image](https://github.com/user-attachments/assets/03533cc3-7b04-4481-93ce-18cdedbf2cd6)

<br/>

### 메인 페이지
![image](https://github.com/user-attachments/assets/e141433f-b94c-4994-bce4-2b8f88e61211)
