### PR TITLE
fix: 핫이슈 알림 클릭 시 루트 페이지로 이동

### DIFF
--- a/frontend/src/components/layout/SidebarAlarm/AlarmCard.tsx
+++ b/frontend/src/components/layout/SidebarAlarm/AlarmCard.tsx
@@ -18,7 +18,11 @@ export const AlarmCard = ({ title, content, isChecked, createdAt, targetType, ta
 
   const handleNavigate = () => {
     if (targetType) {
-      navigate(targetId != null ? `/${targetType.toLowerCase()}/${targetId}` : `/${targetType.toLowerCase()}`)
+      if (targetType.toLowerCase() === 'news') {
+        navigate(targetId != null ? `/${targetType.toLowerCase()}/${targetId}` : `/}`)
+      } else {
+        navigate(targetId != null ? `/${targetType.toLowerCase()}/${targetId}` : `/${targetType.toLowerCase()}`)
+      }
     }
   }
 

--- a/frontend/src/components/layout/SidebarAlarm/SidebarAlarm.tsx
+++ b/frontend/src/components/layout/SidebarAlarm/SidebarAlarm.tsx
@@ -1,58 +1,23 @@
-import { useEffect, useRef, useState } from 'react'
+import { useRef, useEffect } from 'react'
 import clsx from 'clsx'
 import { Icon } from '../../ui/Icon'
 import { AlarmCard } from './AlarmCard'
-import { useSidebarAlarmStore } from '@/stores/useSidebarAlarmStore'
-import { useRequestStore } from '@/stores/useRequestStore'
-import { getRelativeDate } from '@/utils/getRelativeDate'
-import { ENDPOINTS } from '@/constants/url'
 import { AlarmMessage, AlarmType } from '@/constants/AlarmMessage'
-
-type Alarm = {
-  id: number
-  title: string
-  content: string
-  isChecked: boolean
-  createdAt: string | null
-  targetType: string
-  targetId: number
-}
-
-type AlarmGroup = {
-  type: 'all' | 'bookmark'
-  alarms: Alarm[]
-}
+import { getRelativeDate } from '@/utils/getRelativeDate'
+import { useSidebarAlarmLogic } from './useAlarmLogic'
 
 export const SidebarAlarm = () => {
-  const isOpen = useSidebarAlarmStore((state) => state.isOpen)
-  const close = useSidebarAlarmStore((state) => state.close)
+  const {
+    isOpen,
+    close,
+    activeTab,
+    setActiveTab,
+    handleAlarmClick,
+    filteredAlarms,
+    isLoading,
+  } = useSidebarAlarmLogic()
+
   const SidebarAlarmRef = useRef<HTMLDivElement>(null)
-
-  const [activeTab, setActiveTab] = useState<AlarmType.ALL | AlarmType.BOOKMARK>(AlarmType.ALL)
-  const [alarmsData, setAlarmsData] = useState<AlarmGroup[]>([])
-
-  const { getData, patchData, isLoading } = useRequestStore()
-
-  useEffect(() => {
-    const fetchAlarms = async () => {
-      try {
-        const res = await getData<{ success: boolean; message: string; data: AlarmGroup[] }>(ENDPOINTS.ALARM)
-        if (res.success) {
-          setAlarmsData(res.data)
-        }
-      } catch (error) {
-        console.error('알림 가져오기 실패:', error)
-      }
-    }
-
-    if (isOpen) fetchAlarms()
-  }, [isOpen, getData])
-
-  useEffect(() => {
-    if (isOpen) {
-      setActiveTab(AlarmType.ALL)
-    }
-  }, [isOpen])
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -63,30 +28,6 @@ export const SidebarAlarm = () => {
     document.addEventListener('mousedown', handleClickOutside)
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [isOpen, close])
-
-  const handleAlarmClick = async (alarm: Alarm) => {
-    if (!alarm.isChecked) {
-      try {
-        await patchData(ENDPOINTS.ALARM_CHECK(alarm.id))
-        setAlarmsData((prev) =>
-          prev.map((group) =>
-            group.type === tabType
-              ? {
-                  ...group,
-                  alarms: group.alarms.map((a) => (a.id === alarm.id ? { ...a, isChecked: true } : a)),
-                }
-              : group,
-          ),
-        )
-      } catch (e) {
-        console.error('알림 확인 실패:', e)
-      }
-    }
-    close()
-  }
-
-  const tabType = activeTab === AlarmType.ALL ? 'all' : 'bookmark'
-  const filteredAlarms = alarmsData.find((group) => group.type === tabType)?.alarms ?? []
 
   const wrapperClass = clsx(
     'absolute top-0 right-0 h-full w-full bg-alarmBarBg z-50',

--- a/frontend/src/components/layout/SidebarAlarm/useAlarmLogic.ts
+++ b/frontend/src/components/layout/SidebarAlarm/useAlarmLogic.ts
@@ -1,0 +1,87 @@
+import { useEffect, useState } from 'react'
+import { useSidebarAlarmStore } from '@/stores/useSidebarAlarmStore'
+import { useRequestStore } from '@/stores/useRequestStore'
+import { ENDPOINTS } from '@/constants/url'
+import { AlarmType } from '@/constants/AlarmMessage'
+
+export type Alarm = {
+  id: number
+  title: string
+  content: string
+  isChecked: boolean
+  createdAt: string | null
+  targetType: string
+  targetId: number
+}
+
+export type AlarmGroup = {
+  type: 'all' | 'bookmark'
+  alarms: Alarm[]
+}
+
+export const useSidebarAlarmLogic = () => {
+  const isOpen = useSidebarAlarmStore((state) => state.isOpen)
+  const close = useSidebarAlarmStore((state) => state.close)
+
+  const [activeTab, setActiveTab] = useState<AlarmType.ALL | AlarmType.BOOKMARK>(AlarmType.ALL)
+  const [alarmsData, setAlarmsData] = useState<AlarmGroup[]>([])
+
+  const { getData, patchData, isLoading } = useRequestStore()
+
+  useEffect(() => {
+    const fetchAlarms = async () => {
+      try {
+        const res = await getData<{ success: boolean; message: string; data: AlarmGroup[] }>(ENDPOINTS.ALARM)
+        if (res.success) {
+          setAlarmsData(res.data)
+        }
+      } catch (error) {
+        console.error('알림 가져오기 실패:', error)
+      }
+    }
+
+    if (isOpen) fetchAlarms()
+  }, [isOpen, getData])
+
+  useEffect(() => {
+    if (isOpen) {
+      setActiveTab(AlarmType.ALL)
+    }
+  }, [isOpen])
+
+  const handleAlarmClick = async (alarm: Alarm) => {
+    if (!alarm.isChecked) {
+      try {
+        await patchData(ENDPOINTS.ALARM_CHECK(alarm.id))
+        setAlarmsData((prev) =>
+          prev.map((group) =>
+            group.type === tabType
+              ? {
+                  ...group,
+                  alarms: group.alarms.map((a) => (a.id === alarm.id ? { ...a, isChecked: true } : a)),
+                }
+              : group,
+          ),
+        )
+      } catch (e) {
+        console.error('알림 확인 실패:', e)
+      }
+    }
+    close()
+  }
+
+  const tabType = activeTab === AlarmType.ALL ? 'all' : 'bookmark'
+  const filteredAlarms = alarmsData.find((group) => group.type === tabType)?.alarms ?? []
+
+  return {
+    isOpen,
+    close,
+    activeTab,
+    setActiveTab,
+    alarmsData,
+    setAlarmsData,
+    handleAlarmClick,
+    filteredAlarms,
+    isLoading,
+  }
+}


### PR DESCRIPTION
## 연관된 이슈
#264 

<br/>

## 작업 내용
- [x] 알림 컨테이너 로직을 커스텀 훅으로 분리
- [x] 뉴스 알림 id가 없을 시 루트 페이지로 이동

<br/>

## 상세 내용
### 뉴스 알림 id가 없을 시 루트 페이지로 이동
- **작업한 파일:** `src/components/layout/SidebarAlarm/AlarmCard.tsx`
- **작업 내용**
```tsx
const handleNavigate = () => {
  if (targetType) {
    if (targetType.toLowerCase() === 'news') {
      navigate(targetId != null ? `/${targetType.toLowerCase()}/${targetId}` : `/}`)
    } else {
      navigate(targetId != null ? `/${targetType.toLowerCase()}/${targetId}` : `/${targetType.toLowerCase()}`)
    }
  }
}
```