### PR TITLE
fix: 알림 카드 내비게이션 루트 경로 오타 수정

### DIFF
--- a/frontend/src/components/layout/SidebarAlarm/AlarmCard.tsx
+++ b/frontend/src/components/layout/SidebarAlarm/AlarmCard.tsx
@@ -19,7 +19,7 @@ export const AlarmCard = ({ title, content, isChecked, createdAt, targetType, ta
   const handleNavigate = () => {
     if (targetType) {
       if (targetType.toLowerCase() === 'news') {
-        navigate(targetId != null ? `/${targetType.toLowerCase()}/${targetId}` : `/}`)
+        navigate(targetId != null ? `/${targetType.toLowerCase()}/${targetId}` : `/`)
       } else {
         navigate(targetId != null ? `/${targetType.toLowerCase()}/${targetId}` : `/${targetType.toLowerCase()}`)
       }


### PR DESCRIPTION
## 연관된 이슈
#264 

<br/>

## 작업 내용
- [x] 핫이슈 알림 리다이렉트 경로 수정

<br/>

## 상세 내용
### 핫이슈 알림 리다이렉트 경로 수정
- **작업한 파일:** `/src/components/layout/SidebarAlarm/AlarmCard.tsx`
- **작업 내용:** 핫이슈 알림 리다이렉트되는 경로를 `/}` 에서 `/`로 수정