### PR TITLE
fix: 폴링 시 offset, hasNext 값이 덮어 쓰이지 않도록 수정

### DIFF
--- a/frontend/src/components/layout/SidebarMenu/SidebarMenu.tsx
+++ b/frontend/src/components/layout/SidebarMenu/SidebarMenu.tsx
@@ -50,7 +50,7 @@ export const SidebarMenu = () => {
           <Link to={INQUIRY_URL} className="text-menuItem" onClick={close} target="_blank" rel="noopener noreferrer">
             문의하기
           </Link>
-          <Text className="text-menuMetaText">v3.3.0 25.07.13</Text>
+          <Text className="text-menuMetaText">v3.3.1 25.07.18</Text>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/PN/PN-001/hooks/useFetchNormal.ts
+++ b/frontend/src/pages/PN/PN-001/hooks/useFetchNormal.ts
@@ -50,15 +50,13 @@ export const useFetchNormal = () => {
           const newList = res.data[category]?.newsList ?? []
           const prevList = prev[category]?.newsList ?? []
 
-          const appendedList = prevList.length > newList.length ? prevList : newList
-
-          if (prevList.length === newList.length && prevList[0]?.id === newList[0]?.id) {
-            continue
-          }
+          const newItems = newList.filter((newItem) => !prevList.some((prevItem) => prevItem.id === newItem.id))
 
           updated[category] = {
             ...res.data[category],
-            newsList: appendedList,
+            offset: prev[category]?.offset ?? 0,
+            hasNext: prev[category]?.hasNext ?? true,
+            newsList: [...newItems, ...prevList],
           }
         }
 


### PR DESCRIPTION
## 연관된 이슈
#272 

<br/>

## 작업 내용
- [x] 폴링 시 offset, hasNext 값이 덮어 쓰이지 않도록 수정

<br/>

## 상세 내용
###  폴링 시 offset, hasNext 값이 덮어 쓰이지 않도록 수정
- **작업한 파일:** `\src\pages\PN\PN-001\hooks\useFetchNormal.ts`
- **작업 내용:** 최신 뉴스 폴링 시 offset, hasNext가 덮어 쓰이지 않도록 명시적으로 수정
```ts
  const fetchLatestNews = useCallback(async () => {
    try {
      const res = await getData(ENDPOINTS.NEWS_FETCH())

      setNewsByCategory((prev) => {
        const updated: NewsByCategory = { ...prev }

        for (const category in res.data) {
          const newList = res.data[category]?.newsList ?? []
          const prevList = prev[category]?.newsList ?? []

          const newItems = newList.filter((newItem) => !prevList.some((prevItem) => prevItem.id === newItem.id))

          updated[category] = {
            ...res.data[category],
            offset: prev[category]?.offset ?? 0,
            hasNext: prev[category]?.hasNext ?? true,
            newsList: [...newItems, ...prevList],
          }
        }

        return updated
      })
    } catch (err) {
      console.error('자동 새로고침 뉴스 로딩 오류:', err)
    }
  }, [getData])
```